### PR TITLE
Remove build-essential dependency from cuda-nvcc to fix apt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN case "${LINUX_VER}" in \
         && apt-get download cuda-nvcc-${PKG_CUDA_VER} \
         && dpkg -i --ignore-depends="build-essential" ./cuda-nvcc-*.deb \
         && rm ./cuda-nvcc-*.deb \
-        && rm -rf "/var/lib/apt/lists/*"; \
+        && rm -rf "/var/lib/apt/lists/*" \
+        && sed -i 's/Depends: cuda-cudart-dev-11-5, build-essential/Depends: cuda-cudart-dev-11-5/g' /var/lib/dpkg/status; \
         ;; \
       "centos"*) \
         PKG_CUDA_VER="$(echo ${CUDA_VER} | cut -d '.' -f1,2 | tr '.' '-')" \


### PR DESCRIPTION
In the default state, because of the way cuda-nvcc-* is installed without `build-essential`, apt ends up broken and complaining about this when trying to install another package:
```
sevagh:rmm $ docker run --rm -it --entrypoint /bin/bash rapidsai-ci-local
(base) root@d7f53085c2c6:/# apt-get update -y && apt-get install -y python3.8-venv
Hit:1 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease
Hit:2 http://archive.ubuntu.com/ubuntu bionic InRelease
Hit:3 http://security.ubuntu.com/ubuntu bionic-security InRelease
Hit:4 http://archive.ubuntu.com/ubuntu bionic-updates InRelease
Hit:5 http://archive.ubuntu.com/ubuntu bionic-backports InRelease
Reading package lists... Done
Reading package lists... Done
Building dependency tree
Reading state information... Done
You might want to run 'apt --fix-broken install' to correct these.
The following packages have unmet dependencies:
 cuda-nvcc-11-5 : Depends: build-essential but it is not going to be installed
 python3.8-venv : Depends: python3.8 (= 3.8.0-3ubuntu1~18.04.2) but it is not going to be installed
                  Depends: python-pip-whl (>= 8.1.0-2) but it is not going to be installed
E: Unmet dependencies. Try 'apt --fix-broken install' with no packages (or specify a solution).
```
After this workaround, it works:
```
sevagh:rmm $ docker run --rm -it --entrypoint /bin/bash rapidsai-ci-local
(base) root@068e1113be23:/# apt-get update -y && apt-get install -y python3.8-venv
Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
Hit:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease
Hit:3 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease
Hit:4 http://archive.ubuntu.com/ubuntu bionic-backports InRelease
Hit:5 http://security.ubuntu.com/ubuntu bionic-security InRelease
Reading package lists... Done
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following additional packages will be installed:
  file libexpat1 libmagic-mgc libmagic1 libmpdec2 libpython3.8-minimal libpython3.8-stdlib mime-support python-pip-whl python3.8 python3.8-minimal
  xz-utils
Suggested packages:
  python3.8-doc binutils binfmt-support
The following NEW packages will be installed:
  file libexpat1 libmagic-mgc libmagic1 libmpdec2 libpython3.8-minimal libpython3.8-stdlib mime-support python-pip-whl python3.8 python3.8-minimal
  python3.8-venv xz-utils
0 upgraded, 13 newly installed, 0 to remove and 1 not upgraded.
Need to get 6755 kB of archives.
After this operation, 26.9 MB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 libpython3.8-minimal amd64 3.8.0-3ubuntu1~18.04.2 [704 kB]
Get:2 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libexpat1 amd64 2.2.5-3ubuntu0.7 [82.6 kB]
Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 python3.8-minimal amd64 3.8.0-3ubuntu1~18.04.2 [1807 kB]
Get:4 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libmagic-mgc amd64 1:5.32-2ubuntu0.4 [184 kB]
Get:5 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libmagic1 amd64 1:5.32-2ubuntu0.4 [68.6 kB]
Get:6 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 file amd64 1:5.32-2ubuntu0.4 [22.1 kB]
Get:7 http://archive.ubuntu.com/ubuntu bionic/main amd64 libmpdec2 amd64 2.4.2-1ubuntu1 [84.1 kB]
Get:8 http://archive.ubuntu.com/ubuntu bionic/main amd64 mime-support all 3.60ubuntu1 [30.1 kB]
Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 xz-utils amd64 5.2.2-1.3ubuntu0.1 [83.8 kB]
Get:10 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 libpython3.8-stdlib amd64 3.8.0-3ubuntu1~18.04.2 [1676 kB]
Get:11 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 python-pip-whl all 9.0.1-2.3~ubuntu1.18.04.5 [1653 kB]
Get:12 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 python3.8 amd64 3.8.0-3ubuntu1~18.04.2 [355 kB]
Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 python3.8-venv amd64 3.8.0-3ubuntu1~18.04.2 [5304 B]
...
```