### PR TITLE
Add `workflow_dispatch` trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+  workflow_dispatch:
 
 jobs:
   build-images:


### PR DESCRIPTION
This PR adds a `workflow_dispatch` trigger to the GitHub Action which publishes our images.

This will enable us to trigger the CI images to be re-published from other workflows (e.g. when updates are made to `gha-tools`, `rapids-dependency-file-generator`, or the parent `mambaforge-cuda` images).