### PR TITLE
Add git safe.directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,8 @@ RUN rapids-mamba-retry install -y \
     sccache \
   && conda clean -aipty
 
+RUN /opt/conda/bin/git config --global --add safe.directory '*'
+
 # Install CI tools using pip
 RUN pip install rapids-dependency-file-generator \
     && pip cache purge


### PR DESCRIPTION
This PR runs `git config --global --add safe.directory '*'` to prevent any errors from occurring that are related to unsafe directories.

This flag is described in the GitHub blog post below. It was originally added to allow exceptions for a vulnerability that affects multi-user machines. Since the vulnerability isn't relevant to our CI images, we can simply add all of the directories as safe directories with this wildcard (`*`) entry.

- https://github.blog/2022-04-12-git-security-vulnerability-announced/