### PR TITLE
Update `git config` command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN rapids-mamba-retry install -y \
     sccache \
   && conda clean -aipty
 
-RUN /opt/conda/bin/git config --global --add safe.directory '*'
+RUN /opt/conda/bin/git config --system --add safe.directory '*'
 
 # Install CI tools using pip
 RUN pip install rapids-dependency-file-generator \


### PR DESCRIPTION
This PR updates the `git config` command to use the `--system` flag instead of the `--global` flag.

This should make the `safe.directory` configuration option consistent with the other `git config` options shown in the screenshot below.

![image](https://user-images.githubusercontent.com/7400326/191311149-b000b38b-fa9d-4d92-99d5-85deb4163442.png)
