### PR TITLE
Add `gh` CLI tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ RUN rapids-mamba-retry install -y \
     anaconda-client \
     awscli \
     boa \
+    gh \
     git \
     jq \
     ninja \


### PR DESCRIPTION
This PR adds the `gh` CLI tool to our CI images ([src](https://anaconda.org/conda-forge/gh)). This will be useful when programmatically invoking workflows that are configured to be run via a `workflow_dispatch` event.

See https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow for more details.