### PR TITLE
Temporarily add `--nogpgcheck` flag to `yum update`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ RUN \
         && rm -rf "/var/lib/apt/lists/*"; \
         ;; \
       "centos"* | "rockylinux"*) \
-        yum -y update \
+        # FIXME: remove `--nogpgcheck` flag when key signing issue is resolved
+        yum -y update --nogpgcheck \
         && yum -y install --setopt=install_weak_deps=False \
           cuda-cudart-devel-${PKG_CUDA_VER} \
           cuda-driver-devel-${PKG_CUDA_VER} \


### PR DESCRIPTION
It seems that there is a key issue with the `rockylinux` image builds pertaining to key signing ([build log](https://github.com/rapidsai/ci-imgs/actions/runs/3330586010/jobs/5644101364#step:8:373)).

This PR adds the `--nogpgcheck` flag to get us unblocked for now. We should remove this flag in the future once the key signing issue is resolved.