### PR TITLE
Remove `ninja` & `CMAKE_GENERATOR` environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ ENV RAPIDS_CUDA_VERSION="${CUDA_VER}"
 ENV RAPIDS_PY_VERSION="${PYTHON_VER}"
 
 # Add sccache/build variables
-ENV CMAKE_GENERATOR=Ninja
 ENV CMAKE_CUDA_COMPILER_LAUNCHER=sccache
 ENV CMAKE_CXX_COMPILER_LAUNCHER=sccache
 ENV CMAKE_C_COMPILER_LAUNCHER=sccache
@@ -75,7 +74,6 @@ RUN rapids-mamba-retry install -y \
     gh \
     git \
     jq \
-    ninja \
     sccache \
   && conda clean -aipty
 


### PR DESCRIPTION
`ninja` should not be included by default in our CI images. Instead, it should be included in the conda recipe of any packages that require it.

Removing `ninja` from the CI images also means we should remove the associated `CMAKE_GENERATOR=ninja` value.