### PR TITLE
Disable conda notices.

### DIFF
--- a/context/condarc.tmpl
+++ b/context/condarc.tmpl
@@ -10,3 +10,4 @@ conda-build:
   set_build_id: false
   root_dir: $RAPIDS_CONDA_BLD_ROOT_DIR
   output_folder: $RAPIDS_CONDA_BLD_OUTPUT_DIR
+number_channel_notices: 0


### PR DESCRIPTION
This PR disables notices from conda channels in CI output, to avoid a potential point of failure (fetching the notice files).

In the GitHub Actions PR for cudf, I am seeing several errors like `Retrieving notices: ...working... failed` that are not fixed by retrying. Job: https://github.com/rapidsai/cudf/actions/runs/3524821102/jobs/5911784450

<details><summary>Longer error output</summary>

```
Retrieving notices: ...working... failed

# >>>>>>>>>>>>>>>>>>>>>> ERROR REPORT <<<<<<<<<<<<<<<<<<<<<<

    Traceback (most recent call last):
      File "/opt/conda/lib/python3.9/site-packages/urllib3/connectionpool.py", line 386, in _make_request
        self._validate_conn(conn)
      File "/opt/conda/lib/python3.9/site-packages/urllib3/connectionpool.py", line 1042, in _validate_conn
        conn.connect()
      File "/opt/conda/lib/python3.9/site-packages/urllib3/connection.py", line 414, in connect
        self.sock = ssl_wrap_socket(
      File "/opt/conda/lib/python3.9/site-packages/urllib3/util/ssl_.py", line 449, in ssl_wrap_socket
        ssl_sock = _ssl_wrap_socket_impl(
      File "/opt/conda/lib/python3.9/site-packages/urllib3/util/ssl_.py", line 493, in _ssl_wrap_socket_impl
        return ssl_context.wrap_socket(sock, server_hostname=server_hostname)
      File "/opt/conda/lib/python3.9/ssl.py", line 501, in wrap_socket
        return self.sslsocket_class._create(
      File "/opt/conda/lib/python3.9/ssl.py", line 1041, in _create
        self.do_handshake()
      File "/opt/conda/lib/python3.9/ssl.py", line 1310, in do_handshake
        self._sslobj.do_handshake()
    socket.timeout: _ssl.c:1112: The handshake operation timed out
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "/opt/conda/lib/python3.9/site-packages/urllib3/connectionpool.py", line 703, in urlopen
        httplib_response = self._make_request(
      File "/opt/conda/lib/python3.9/site-packages/urllib3/connectionpool.py", line 389, in _make_request
        self._raise_timeout(err=e, url=url, timeout_value=conn.timeout)
      File "/opt/conda/lib/python3.9/site-packages/urllib3/connectionpool.py", line 340, in _raise_timeout
        raise ReadTimeoutError(
    urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='conda.anaconda.org', port=443): Read timed out. (read timeout=5)
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "/opt/conda/lib/python3.9/site-packages/requests/adapters.py", line 489, in send
        resp = conn.urlopen(
      File "/opt/conda/lib/python3.9/site-packages/urllib3/connectionpool.py", line 815, in urlopen
        return self.urlopen(
      File "/opt/conda/lib/python3.9/site-packages/urllib3/connectionpool.py", line 815, in urlopen
        return self.urlopen(
      File "/opt/conda/lib/python3.9/site-packages/urllib3/connectionpool.py", line 815, in urlopen
        return self.urlopen(
      File "/opt/conda/lib/python3.9/site-packages/urllib3/connectionpool.py", line 787, in urlopen
        retries = retries.increment(
      File "/opt/conda/lib/python3.9/site-packages/urllib3/util/retry.py", line 592, in increment
        raise MaxRetryError(_pool, url, error or ResponseError(cause))
    urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='conda.anaconda.org', port=443): Max retries exceeded with url: /dask/label/dev/notices.json (Caused by ReadTimeoutError("HTTPSConnectionPool(host='conda.anaconda.org', port=443): Read timed out. (read timeout=5)"))
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "/opt/conda/lib/python3.9/site-packages/conda/exceptions.py", line 1129, in __call__
        return func(*args, **kwargs)
      File "/opt/conda/lib/python3.9/site-packages/conda_env/cli/main.py", line 80, in do_call
        exit_code = getattr(module, func_name)(args, parser)
      File "/opt/conda/lib/python3.9/site-packages/conda/notices/core.py", line 75, in wrapper
        display_notices(
      File "/opt/conda/lib/python3.9/site-packages/conda/notices/core.py", line 39, in display_notices
        channel_notice_responses = http.get_notice_responses(channel_name_urls, silent=silent)
      File "/opt/conda/lib/python3.9/site-packages/conda/notices/http.py", line 36, in get_notice_responses
        return tuple(
      File "/opt/conda/lib/python3.9/site-packages/conda/notices/http.py", line 39, in <genexpr>
        (
      File "/opt/conda/lib/python3.9/concurrent/futures/_base.py", line 609, in result_iterator
        yield fs.pop().result()
      File "/opt/conda/lib/python3.9/concurrent/futures/_base.py", line 446, in result
        return self.__get_result()
      File "/opt/conda/lib/python3.9/concurrent/futures/_base.py", line 391, in __get_result
        raise self._exception
      File "/opt/conda/lib/python3.9/concurrent/futures/thread.py", line 58, in run
        result = self.fn(*self.args, **self.kwargs)
      File "/opt/conda/lib/python3.9/site-packages/conda/notices/http.py", line 42, in <lambda>
        lambda args: get_channel_notice_response(*args), url_and_names
      File "/opt/conda/lib/python3.9/site-packages/conda/notices/cache.py", line 37, in wrapper
        return_value = func(url, name)
      File "/opt/conda/lib/python3.9/site-packages/conda/notices/http.py", line 58, in get_channel_notice_response
        resp = session.get(url, allow_redirects=False, timeout=5)  # timeout: connect, read
      File "/opt/conda/lib/python3.9/site-packages/requests/sessions.py", line 600, in get
        return self.request("GET", url, **kwargs)
      File "/opt/conda/lib/python3.9/site-packages/requests/sessions.py", line 587, in request
        resp = self.send(prep, **send_kwargs)
      File "/opt/conda/lib/python3.9/site-packages/requests/sessions.py", line 701, in send
        r = adapter.send(request, **kwargs)
      File "/opt/conda/lib/python3.9/site-packages/requests/adapters.py", line 565, in send
        raise ConnectionError(e, request=request)
    requests.exceptions.ConnectionError: HTTPSConnectionPool(host='conda.anaconda.org', port=443): Max retries exceeded with url: /dask/label/dev/notices.json (Caused by ReadTimeoutError("HTTPSConnectionPool(host='conda.anaconda.org', port=443): Read timed out. (read timeout=5)"))
```

</details>

I don't think we need to show channel notices in our CI output, so we shouldn't bother fetching them (an unnecessary network task that can cause CI failure). A [related (but not identical) issue](https://github.com/conda/conda/issues/11743) suggested setting `CONDA_NUMBER_CHANNEL_NOTICES` to `0`. We can do the same via the [conda configuration](https://docs.conda.io/projects/conda/en/latest/configuration.html), which this PR modifies.

```
# # number_channel_notices (int)
# #   Sets the number of channel notices to be displayed when running
# #   commands the "install", "create", "update", "env create", and "env
# #   update" . Defaults to 5. In order to completely suppress channel
# #   notices, set this to 0.
# # 
# number_channel_notices: 5
```