### PR TITLE
Pin `rapids-dependency-file-generator` to major version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ RUN cat /tmp/condarc.tmpl | envsubst | tee /opt/conda/.condarc; \
 RUN /opt/conda/bin/git config --system --add safe.directory '*'
 
 # Install CI tools using pip
-RUN pip install rapids-dependency-file-generator \
+RUN pip install rapids-dependency-file-generator==1 \
     && pip cache purge
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
With https://github.com/rapidsai/dependency-file-generator/issues/12 closed and semantic versioning enabled for `rapids-dependency-file-generator`, we can now pin to the latest major version in our CI images to prevent any releases with breaking changes from breaking our CI images.

v1.0.0 release - https://github.com/rapidsai/dependency-file-generator/releases/tag/v1.0.0