### PR TITLE
Install `codecov` binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ ARG LINUX_VER=ubuntu18.04
 ARG PYTHON_VER=3.8
 FROM rapidsai/mambaforge-cuda:cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER}
 
+ARG TARGETPLATFORM
 ARG CUDA_VER
 ARG LINUX_VER
 ARG PYTHON_VER
@@ -79,17 +80,24 @@ RUN rapids-mamba-retry install -y \
 
 # Install codecov binary
 RUN \
-  CODECOV_VERSION=v0.3.2 \
-  && curl https://uploader.codecov.io/verification.gpg --max-time 10 --retry 5 \
-    | gpg --no-default-keyring --keyring trustedkeys.gpg --import \
-  && curl -Os --max-time 10 --retry 5 https://uploader.codecov.io/${CODECOV_VERSION}/linux/codecov \
-  && curl -Os --max-time 10 --retry 5 https://uploader.codecov.io/${CODECOV_VERSION}/linux/codecov.SHA256SUM \
-  && curl -Os --max-time 10 --retry 5 https://uploader.codecov.io/${CODECOV_VERSION}/linux/codecov.SHA256SUM.sig \
-  && gpgv codecov.SHA256SUM.sig codecov.SHA256SUM \
-  && shasum -a 256 -c codecov.SHA256SUM \
-  && chmod +x codecov \
-  && mv codecov /usr/local/bin \
-  && rm -f codecov*
+  case "${TARGETPLATFORM}" in \
+    "linux/amd64") \
+      CODECOV_VERSION=v0.3.2 \
+      && curl https://uploader.codecov.io/verification.gpg --max-time 10 --retry 5 \
+        | gpg --no-default-keyring --keyring trustedkeys.gpg --import \
+      && curl -Os --max-time 10 --retry 5 https://uploader.codecov.io/${CODECOV_VERSION}/linux/codecov \
+      && curl -Os --max-time 10 --retry 5 https://uploader.codecov.io/${CODECOV_VERSION}/linux/codecov.SHA256SUM \
+      && curl -Os --max-time 10 --retry 5 https://uploader.codecov.io/${CODECOV_VERSION}/linux/codecov.SHA256SUM.sig \
+      && gpgv codecov.SHA256SUM.sig codecov.SHA256SUM \
+      && shasum -a 256 -c codecov.SHA256SUM \
+      && chmod +x codecov \
+      && mv codecov /usr/local/bin \
+      && rm -f codecov* \
+      ;; \
+    *) \
+      echo 'Codecov is only supported on "linux/amd64" machines'; \
+      ;; \
+  esac
 
 # Create condarc file from env vars
 ENV RAPIDS_CONDA_BLD_ROOT_DIR=/tmp/conda-bld-workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,20 @@ RUN rapids-mamba-retry install -y \
     sccache \
   && conda clean -aipty
 
+# Install codecov binary
+RUN \
+  CODECOV_VERSION=v0.3.2 \
+  && curl https://uploader.codecov.io/verification.gpg --max-time 10 --retry 5 \
+    | gpg --no-default-keyring --keyring trustedkeys.gpg --import \
+  && curl -Os --max-time 10 --retry 5 https://uploader.codecov.io/${CODECOV_VERSION}/linux/codecov \
+  && curl -Os --max-time 10 --retry 5 https://uploader.codecov.io/${CODECOV_VERSION}/linux/codecov.SHA256SUM \
+  && curl -Os --max-time 10 --retry 5 https://uploader.codecov.io/${CODECOV_VERSION}/linux/codecov.SHA256SUM.sig \
+  && gpgv codecov.SHA256SUM.sig codecov.SHA256SUM \
+  && shasum -a 256 -c codecov.SHA256SUM \
+  && chmod +x codecov \
+  && mv codecov /usr/local/bin \
+  && rm -f codecov*
+
 # Create condarc file from env vars
 ENV RAPIDS_CONDA_BLD_ROOT_DIR=/tmp/conda-bld-workspace
 ENV RAPIDS_CONDA_BLD_OUTPUT_DIR=/tmp/conda-bld-output


### PR DESCRIPTION
This PR adds the `codecov` binary to our images. Initially we were using their GH Action, [codecov-action](https://github.com/codecov/codecov-action), but the action seemed to intermittently hang when trying to retrieve the checksum files (perhaps due to networking issues within the VPN).

Preinstalling `codecov` in our CI images should help prevent those intermittent failures.