### PR TITLE
Remove workflow timeout

### DIFF
--- a/.github/workflows/build-and-publish-images.yml
+++ b/.github/workflows/build-and-publish-images.yml
@@ -70,7 +70,6 @@ jobs:
           CUDA_VER: ${{ matrix.CUDA_VER }}
           LINUX_VER: ${{ matrix.LINUX_VER }}
       - name: Build and push
-        timeout-minutes: 30
         uses: docker/build-push-action@v3
         with:
           context: context


### PR DESCRIPTION
This timeout doesn't serve a purpose. QEMU builds should eventually finish, even if they take a while.
