### PR TITLE
Add libGL to image dependencies.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN \
           cuda-gdb-${PKG_CUDA_VER} \
           cuda-cudart-dev-${PKG_CUDA_VER} \
           cuda-cupti-dev-${PKG_CUDA_VER} \
+          libgl1 \
           wget \
         # ignore the build-essential package since it installs dependencies like gcc/g++
         # we don't need them since we use conda compilers, so this keeps our images smaller
@@ -51,6 +52,7 @@ RUN \
           cuda-driver-devel-${PKG_CUDA_VER} \
           cuda-gdb-${PKG_CUDA_VER} \
           cuda-cupti-${PKG_CUDA_VER} \
+          mesa-libGL \
           wget \
           which \
           yum-utils \


### PR DESCRIPTION
Potential fix for OpenCV issues in https://github.com/rapidsai/cucim/pull/471.

(There are alternative fixes to consider, so this PR may be closed if another route is taken.)