### PR TITLE
Add `always_yes: true` to `.condarc` file

### DIFF
--- a/context/condarc.tmpl
+++ b/context/condarc.tmpl
@@ -11,3 +11,4 @@ conda-build:
   root_dir: $RAPIDS_CONDA_BLD_ROOT_DIR
   output_folder: $RAPIDS_CONDA_BLD_OUTPUT_DIR
 number_channel_notices: 0
+always_yes: true


### PR DESCRIPTION
Who is `conda` to make us second guess ourselves? Of course we want to install those dependencies.

This PR adds `always_yes: true` to our `.condarc` file so that `conda` won't prompt the user when performing `conda install` commands.