### PR TITLE
Add `SCCACHE_S3_USE_SSL=true` environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ ENV CMAKE_C_COMPILER_LAUNCHER=sccache
 ENV SCCACHE_BUCKET=rapids-sccache
 ENV SCCACHE_REGION=us-west-2
 ENV SCCACHE_IDLE_TIMEOUT=32768
+ENV SCCACHE_S3_USE_SSL=true
 
 # Install system packages depending on the LINUX_VER
 RUN \


### PR DESCRIPTION
@trxcllnt mentioned that adding this to his DLFW images resulted in much better cache hit rates.

Hopefully it does the same for us. It seems like a logical option to enable regardless.
