### PR TITLE
Update `latest` tag

### DIFF
--- a/axis.yaml
+++ b/axis.yaml
@@ -24,6 +24,6 @@ exclude:
 
 # Define the values used for the "latest" tag
 LATEST_VERSIONS:
-  CUDA_VER: "11.5.1"
-  PYTHON_VER: "3.9"
-  LINUX_VER: "ubuntu20.04"
+  CUDA_VER: "11.8.0"
+  PYTHON_VER: "3.10"
+  LINUX_VER: "ubuntu22.04"


### PR DESCRIPTION
Since the `latest` driver for our self-hosted GPU runners now corresponds to driver `520`, it should be safe to also update the `latest` tag for our CI images to correspond to `11.8` images.

This PR updates those parameters.