### PR TITLE
Update `rapids-dependency-file-generator` version specifier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ RUN cat /tmp/condarc.tmpl | envsubst | tee /opt/conda/.condarc; \
 RUN /opt/conda/bin/git config --system --add safe.directory '*'
 
 # Install CI tools using pip
-RUN pip install rapids-dependency-file-generator==1 \
+RUN pip install "rapids-dependency-file-generator==1.*" \
     && pip cache purge
 
 COPY --from=mikefarah/yq:4.30.8 /usr/bin/yq /usr/local/bin/yq


### PR DESCRIPTION
This PR updates the version specifier for `rapids-dependency-file-generator`

The `==1` syntax apparently only ever installs version `1.0.0`, whereas `==1.*` will install any `1.x` version.

I confirmed this locally.

This is important since version [1.1.0](https://github.com/rapidsai/dependency-file-generator/releases/tag/v1.1.0) was recently released.