### PR TITLE
Update `sccache` version specifier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN rapids-mamba-retry install -y \
     gh \
     git \
     jq \
-    sccache \
+    "sccache>=0.3.2" \
   && conda clean -aipty
 
 # Install codecov binary


### PR DESCRIPTION
After merging #36, the version specifier for `sccache` also needs to be updated.

To use an S3 bucket in `us-east-2`, an `sccache` version that has the changes from [this PR](https://github.com/mozilla/sccache/pull/1403) must be used.

These changes were released in `sccache` version `0.3.2` ([src](https://github.com/mozilla/sccache/releases/tag/v0.3.2)).