### PR TITLE
Add `SCCACHE_S3_NO_CREDENTIALS` environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ ENV SCCACHE_BUCKET=rapids-sccache-east
 ENV SCCACHE_REGION=us-east-2
 ENV SCCACHE_IDLE_TIMEOUT=32768
 ENV SCCACHE_S3_USE_SSL=true
+ENV SCCACHE_S3_NO_CREDENTIALS=false
 
 # Install system packages depending on the LINUX_VER
 RUN \


### PR DESCRIPTION
This change passes through the value of `SCCACHE_S3_NO_CREDENTIALS` to our conda builds, enabling devs to utilize the `sccache` cache that's populated by CI when they are reproducing build issues locally as per [these](https://docs.rapids.ai/resources/reproducing-ci/) instructions.