### PR TITLE
Fix `codecov` installation

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -60,5 +60,4 @@ jobs:
             CUDA_VER=${{ inputs.CUDA_VER }}
             LINUX_VER=${{ inputs.LINUX_VER }}
             PYTHON_VER=${{ inputs.PYTHON_VER }}
-            TARGETPLATFORM=${{ matrix.ARCH }}
           tags: ${{ inputs.IMAGE_NAME }}-${{ matrix.ARCH }}


### PR DESCRIPTION
#61 added an explicit `TARGETPLATFORM` build argument, which broke our CI images.

`TARGETPLATFORM` is a build argument provided by `docker build` automatically: https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope.