### PR TITLE
Add upstream info

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,7 +1,15 @@
 name: publish
+run-name: "publish${{ (inputs.upstream_repository != '') && format(' - triggered by: {0}', inputs.upstream_repository) || '' }}"
 
 on:
   workflow_dispatch:
+    inputs:
+      upstream_repository:
+        required: false
+        type: string
+      upstream_job:
+        required: false
+        type: string
   push:
     branches:
       - main


### PR DESCRIPTION
PR adds information about the triggering upstream job. Also adds the `workflow_dispatch` event. 

NOTE:
- `upstream_job` will be visible as an input parameter for the `publish` job. For instance, [here](https://github.com/rapidsai/ci-imgs/actions/runs/6124467698/job/16624547397#step:1:37).
- `upstream_repository` input is used to display the run name (in the actions page)