### PR TITLE
Use correct latest tag for rapidsai/ci manifest

### DIFF
--- a/ci/create-multiarch-manifest.sh
+++ b/ci/create-multiarch-manifest.sh
@@ -50,8 +50,8 @@ if [[ $IMAGE_NAME =~ ci-conda ]]; then
   ]]; then
     # only create a 'latest' manifest if it is a non-PR workflow.
     if [[ "${BUILD_TYPE}" != "pull-request" ]]; then
-      docker manifest create "rapidsai/${IMAGE_REPO}:latest" "${source_tags[@]}"
-      docker manifest push "rapidsai/${IMAGE_REPO}:latest"
+      docker manifest create "rapidsai/ci:latest" "${source_tags[@]}"
+      docker manifest push "rapidsai/ci:latest"
     else
       echo "Skipping 'latest' manifest creation for PR workflow."
     fi


### PR DESCRIPTION
This PR is a follow up to #72. It updates the code to correctly publish the `:latest` manifest tag for the `rapidsai/ci` image.

The need for this fix was discovered in this [failed job](https://github.com/rapidsai/ci-imgs/actions/runs/6249805589/job/16968023477).