### PR TITLE
Ensure cpython builds are used instead of pypy.

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -82,6 +82,7 @@ RUN rapids-mamba-retry install -y \
     git \
     jq \
     "sccache==0.4.2" \
+    "python=${PYTHON_VERSION}.*=*_cpython" \
   && conda clean -aipty
 
 # Install codecov binary


### PR DESCRIPTION
We ran into an issue where the latest `awscli` build was available for pypy but not cpython, and it made the CI image use pypy which broke things further downstream. This PR requires cpython builds when solving the conda environment. We might be able to fix this [upstream in mambaforge-cuda](https://github.com/rapidsai/mambaforge-cuda/blob/5b00f96658c0067850d598ae7b3b4e24b5c68510/Dockerfile#L25) instead if that constraint is retained for later conda solves in the same environment, but I'm not sure if that's right since it was this install step that caused it to use pypy... cc: @jakirkham