### PR TITLE
Install AWS CLI from DockerHub Images

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -75,7 +75,6 @@ RUN wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.ta
 # Install CI tools using mamba
 RUN rapids-mamba-retry install -y \
     anaconda-client \
-    awscli \
     boa \
     gettext \
     gh \
@@ -120,5 +119,7 @@ RUN pip install dunamai "rapids-dependency-file-generator==1.*" \
     && pip cache purge
 
 COPY --from=mikefarah/yq:4.35.1 /usr/bin/yq /usr/local/bin/yq
+COPY --from=amazon/aws-cli /usr/local/aws-cli/ /usr/local/aws-cli/
+COPY --from=amazon/aws-cli /usr/local/bin/ /usr/local/bin/
 
 CMD ["/bin/bash"]

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -131,12 +131,8 @@ RUN pyenv global ${PYTHON_VER} && python -m pip install auditwheel patchelf twin
 RUN wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
 
 # Install the AWS CLI
-RUN mkdir -p /aws_install && cd /aws_install && \
-    curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
-    unzip awscli-bundle.zip && \
-    ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
-    cd / && \
-    rm -rf /aws_install
+COPY --from=amazon/aws-cli /usr/local/aws-cli/ /usr/local/aws-cli/
+COPY --from=amazon/aws-cli /usr/local/bin/ /usr/local/bin/
 
 # Mark all directories as safe for git so that GHA clones into the root don't
 # run into issues

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -41,13 +41,8 @@ ENV PATH="/pyenv/versions/${PYTHON_VER}/bin/:$PATH"
 
 # Install the AWS CLI
 # Needed to download wheels for running tests
-# Install the AWS CLI
-RUN mkdir -p /aws_install && cd /aws_install && \
-    curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
-    unzip awscli-bundle.zip && \
-    ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
-    cd / && \
-    rm -rf /aws_install
+COPY --from=amazon/aws-cli /usr/local/aws-cli/ /usr/local/aws-cli/
+COPY --from=amazon/aws-cli /usr/local/bin/ /usr/local/bin/
 
 # update git > 2.17
 RUN grep '18.04' /etc/issue && bash -c "apt-get install -y software-properties-common && add-apt-repository ppa:git-core/ppa -y && apt-get update && apt-get install --upgrade -y git" || true;


### PR DESCRIPTION
This PR changes the way we install the AWS CLI from using `conda`/`curl` to using their official DockerHub images.

There are a few motivations for this change:

- The `awscli` package from `conda-forge` has a lot of dependencies, which can cause packages in the base environment to get downgraded
- The `awscli` package from `conda-forge` has different versions published for `amd64` vs `arm64`, which can cause inconsistencies in our images

The result of this change is that all of our images should include the same AWS CLI version.

I'd like to eventually move more of our dependencies away from using `conda`, but we can save that for another time.