### PR TITLE
Update mambaforge to miniforge

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -1,7 +1,7 @@
 ARG CUDA_VER=11.8.0
 ARG LINUX_VER=ubuntu22.04
 ARG PYTHON_VER=3.10
-FROM rapidsai/mambaforge-cuda:cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER}
+FROM rapidsai/miniforge-cuda:cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER}
 
 ARG TARGETPLATFORM
 ARG CUDA_VER


### PR DESCRIPTION
We're renaming our mambaforge images to miniforge as described in [this PR](https://github.com/rapidsai/mambaforge-cuda/pull/51). This PR updates the old references in this repository.