### PR TITLE
Refactor `git` upgrade for `citestwheel`

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -29,7 +29,8 @@ RUN \
     PKG_CUDA_VER="$(echo ${CUDA_VER} | cut -d '.' -f1,2 | tr '.' '-')"; \
     case "${LINUX_VER}" in \
       "ubuntu"*) \
-        apt-get update \
+        echo 'APT::Update::Error-Mode "any";' > /etc/apt/apt.conf.d/warnings-as-errors \
+        && apt-get update \
         && apt-get upgrade -y \
         && apt-get install -y --no-install-recommends \
           cuda-gdb-${PKG_CUDA_VER} \

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -27,13 +27,34 @@ ENV PATH="/pyenv/bin:/pyenv/shims:$PATH"
 
 RUN case "${LINUX_VER}" in \
     "ubuntu"*) \
-        apt update -y && apt install -y jq build-essential software-properties-common wget gcc zlib1g-dev libbz2-dev libssl-dev libreadline-dev libsqlite3-dev libffi-dev curl git libncurses5-dev libnuma-dev openssh-client libcudnn8-dev zip libopenblas-dev liblapack-dev protobuf-compiler autoconf automake libtool cmake && rm -rf /var/lib/apt/lists/* \
-        && add-apt-repository ppa:git-core/ppa && add-apt-repository ppa:ubuntu-toolchain-r/test && apt update -y && apt install -y git gcc-9 g++-9 && add-apt-repository -r ppa:git-core/ppa && add-apt-repository -r ppa:ubuntu-toolchain-r/test \
+        echo 'APT::Update::Error-Mode "any";' > /etc/apt/apt.conf.d/warnings-as-errors \
+        && apt update -y \
+        && apt install -y \
+          jq build-essential software-properties-common wget gcc zlib1g-dev libbz2-dev \
+          libssl-dev libreadline-dev libsqlite3-dev libffi-dev curl git libncurses5-dev \
+          libnuma-dev openssh-client libcudnn8-dev zip libopenblas-dev liblapack-dev \
+          protobuf-compiler autoconf automake libtool cmake \
+        && add-apt-repository ppa:git-core/ppa \
+        && add-apt-repository ppa:ubuntu-toolchain-r/test \
+        && apt update -y \
+        && apt install -y git gcc-9 g++-9 \
+        && add-apt-repository -r ppa:git-core/ppa \
+        && add-apt-repository -r ppa:ubuntu-toolchain-r/test \
         && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90 --slave /usr/bin/g++ g++ /usr/bin/g++-9 --slave /usr/bin/gcov gcov /usr/bin/gcov-9 \
+        && rm -rf /var/lib/apt/lists/* \
       ;; \
     "centos"*) \
-        yum update --exclude=libnccl* -y && yum install -y epel-release wget gcc zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel xz xz-devel libffi-devel curl git ncurses-devel numactl numactl-devel openssh-clients libcudnn8-devel zip blas-devel lapack-devel protobuf-compiler autoconf automake libtool centos-release-scl scl-utils cmake && yum clean all \
-        && yum remove -y git && yum install -y https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm && yum install -y git jq devtoolset-11 && yum remove -y endpoint-repo \
+        yum update --exclude=libnccl* -y \
+        && yum install -y \
+          epel-release wget gcc zlib-devel bzip2 bzip2-devel readline-devel sqlite \
+          sqlite-devel xz xz-devel libffi-devel curl git ncurses-devel numactl \
+          numactl-devel openssh-clients libcudnn8-devel zip blas-devel lapack-devel \
+          protobuf-compiler autoconf automake libtool centos-release-scl scl-utils cmake \
+        && yum remove -y git \
+        && yum install -y https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm \
+        && yum install -y git jq devtoolset-11 \
+        && yum remove -y endpoint-repo \
+        && yum clean all \
         && echo -e ' \
         #!/bin/bash\n \
         source scl_source enable devtoolset-11\n \

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -21,20 +21,21 @@ ENV PATH="/pyenv/bin:/pyenv/shims:$PATH"
 
 RUN <<EOF
 set -e
-if [[ "${LINUX_VER}" == "ubuntu18.04" ]]; then
+if [[ "${LINUX_VER}" =~ "ubuntu" ]]; then
+  echo 'APT::Update::Error-Mode "any";' > /etc/apt/apt.conf.d/warnings-as-errors
   # update git > 2.17
-  apt-get install -y software-properties-common
   add-apt-repository ppa:git-core/ppa -y
 fi
 
-apt-get update -o APT::Update::Error-Mode=any
+apt-get update
 apt-get upgrade -y
 apt-get install -y --no-install-recommends \
   wget curl git jq ssh \
   make build-essential libssl-dev zlib1g-dev \
   libbz2-dev libreadline-dev libsqlite3-dev wget \
   curl llvm libncursesw5-dev xz-utils tk-dev unzip \
-  libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+  libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
+  software-properties-common
 rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 EOF
 

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -21,12 +21,11 @@ ENV PATH="/pyenv/bin:/pyenv/shims:$PATH"
 
 RUN <<EOF
 set -e
-if [[ "${LINUX_VER}" =~ "ubuntu" ]]; then
-  echo 'APT::Update::Error-Mode "any";' > /etc/apt/apt.conf.d/warnings-as-errors
-  # update git > 2.17
-  add-apt-repository ppa:git-core/ppa -y
-fi
-
+echo 'APT::Update::Error-Mode "any";' > /etc/apt/apt.conf.d/warnings-as-errors
+apt-get update
+apt-get install -y software-properties-common
+# update git > 2.17
+add-apt-repository ppa:git-core/ppa -y
 apt-get update
 apt-get upgrade -y
 apt-get install -y --no-install-recommends \

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -33,8 +33,7 @@ apt-get install -y --no-install-recommends \
   make build-essential libssl-dev zlib1g-dev \
   libbz2-dev libreadline-dev libsqlite3-dev wget \
   curl llvm libncursesw5-dev xz-utils tk-dev unzip \
-  libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
-  software-properties-common
+  libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
 rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 EOF
 


### PR DESCRIPTION
This PR refactors how `git` is upgraded in the `citestwheel` image.

Specifically, it adds `APT::Update::Error-Mode=any` to ensure that any transient network errors that occur from `apt update` are treated as errors.

It also moves some code blocks around to consolidate commands and switches a long `RUN` command to use `heredocs`.