### PR TITLE
Switch to anaconda index

### DIFF
--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -186,7 +186,8 @@ RUN pyenv global ${PYTHON_VER} && python -m pip install auditwheel patchelf twin
 RUN wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
 
 # Install anaconda-client
-RUN pip install git+https://github.com/Anaconda-Platform/anaconda-client
+RUN pip install git+https://github.com/Anaconda-Platform/anaconda-client && \
+	pip cache purge
 
 # Install the AWS CLI
 RUN mkdir -p /aws_install && cd /aws_install && \

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -20,7 +20,7 @@ ENV RAPIDS_CUDA_VERSION="${CUDA_VER}"
 ENV RAPIDS_PY_VERSION="${PYTHON_VER}"
 
 # RAPIDS pip index
-ENV PIP_EXTRA_INDEX_URL="https://pypi.k8s.rapids.ai/simple"
+ENV PIP_EXTRA_INDEX_URL="https://pypi.anaconda.org/rapidsai-wheels-nightly/simple"
 
 ENV PYENV_ROOT="/pyenv"
 ENV PATH="/pyenv/bin:/pyenv/shims:$PATH"
@@ -184,6 +184,9 @@ RUN pyenv global ${PYTHON_VER} && python -m pip install auditwheel patchelf twin
 
 # Install latest gha-tools
 RUN wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
+
+# Install anaconda-client
+RUN pip install git+https://github.com/Anaconda-Platform/anaconda-client
 
 # Install the AWS CLI
 RUN mkdir -p /aws_install && cd /aws_install && \

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -12,7 +12,7 @@ ENV RAPIDS_CUDA_VERSION="${CUDA_VER}"
 ENV RAPIDS_PY_VERSION="${PYTHON_VER}"
 
 # RAPIDS pip index
-ENV PIP_EXTRA_INDEX_URL="https://pypi.k8s.rapids.ai/simple"
+ENV PIP_EXTRA_INDEX_URL="https://pypi.anaconda.org/rapidsai-wheels-nightly/simple"
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Following the impending switch to a public index for our wheels packages, this PR updates the `ciwheel` and `citestwheel` images to use the new index URL.

PR also installs the anaconda-client that will be used in a new `rapids-wheels-anaconda` tool to upload our wheels to Anaconda.

Tested in the following runs:
- https://github.com/rapidsai/rmm/actions/runs/6854363962/job/18637251210?pr=1377 (rmm)
- https://github.com/rapidsai/rmm/actions/runs/6854845961/job/18638883092?pr=1377 (rmm)
- https://github.com/rapidsai/cuml/actions/runs/6855519490/job/18642932582?pr=5652 (cuml)

Cross-references:
- https://github.com/rapidsai/shared-workflows/pull/154
- https://github.com/rapidsai/gha-tools/pull/86