### PR TITLE
Add `conda-verify` to run test/imports

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -105,6 +105,7 @@ RUN rapids-mamba-retry install -y \
     anaconda-client \
     awscli \
     boa \
+    conda-verify \
     gettext \
     gh \
     git \


### PR DESCRIPTION
I noticed in our CI logs the following messages for all of our conda builds:

```
2023-11-14T06:32:34.0226057Z Importing conda-verify failed.  Please be sure to test your packages.  conda install conda-verify to make this message go away.
2023-11-14T06:32:34.0228701Z WARNING:conda_build.build:Importing conda-verify failed.  Please be sure to test your packages.  conda install conda-verify to make this message go away.
```

This PR will add `conda-verify` to run these tests.