### PR TITLE
Drop CUDA 11.2 and 11.5, add Python 3.11

### DIFF
--- a/ci/compute-matrix.jq
+++ b/ci/compute-matrix.jq
@@ -1,7 +1,7 @@
 def compute_arch($x):
   ["amd64"] |
-  if 
-    (["ubuntu18.04", "centos7"] | index($x.LINUX_VER) != null) or ($x.CUDA_VER <= "11.2.2")
+  if
+    (["ubuntu18.04", "centos7"] | index($x.LINUX_VER) != null)
    then
     .
   else

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -7,7 +7,6 @@ PYTHON_VER:
   - "3.9"
   - "3.10"
   - "3.11"
-  - "3.12"
 LINUX_VER:
   - "ubuntu18.04"
   - "ubuntu20.04"

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -6,6 +6,8 @@ CUDA_VER:
 PYTHON_VER:
   - "3.9"
   - "3.10"
+  - "3.11"
+  - "3.12"
 LINUX_VER:
   - "ubuntu18.04"
   - "ubuntu20.04"

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -1,7 +1,5 @@
 CUDA_VER:
-  - "11.2.2"
   - "11.4.3"
-  - "11.5.2"
   - "11.8.0"
   - "12.0.1"
   - "12.1.1"
@@ -21,11 +19,7 @@ IMAGE_REPO:
 exclude:
   # ci-conda:
   - LINUX_VER: "ubuntu22.04"
-    CUDA_VER: "11.2.2"
-  - LINUX_VER: "ubuntu22.04"
     CUDA_VER: "11.4.3"
-  - LINUX_VER: "ubuntu22.04"
-    CUDA_VER: "11.5.2"
 
   # wheels:
   - LINUX_VER: "ubuntu18.04"
@@ -34,17 +28,9 @@ exclude:
     IMAGE_REPO: "citestwheel"
 
   # exclude citestwheel and ci-wheel for cuda versions other than 11.8.0 and 12.0.1
-  - CUDA_VER: "11.2.2"
-    IMAGE_REPO: "citestwheel"
-  - CUDA_VER: "11.2.2"
-    IMAGE_REPO: "ci-wheel"
   - CUDA_VER: "11.4.3"
     IMAGE_REPO: "citestwheel"
   - CUDA_VER: "11.4.3"
-    IMAGE_REPO: "ci-wheel"
-  - CUDA_VER: "11.5.2"
-    IMAGE_REPO: "citestwheel"
-  - CUDA_VER: "11.5.2"
     IMAGE_REPO: "ci-wheel"
   - CUDA_VER: "12.1.1"
     IMAGE_REPO: "citestwheel"


### PR DESCRIPTION
This is a follow-up to https://github.com/rapidsai/miniforge-cuda/pull/55.