### PR TITLE
Temporarily re-add `12.1.1`

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -2,6 +2,7 @@ CUDA_VER:
   - "11.4.3"
   - "11.8.0"
   - "12.0.1"
+  - "12.1.1"
   - "12.2.2"
 PYTHON_VER:
   - "3.9"
@@ -34,6 +35,10 @@ exclude:
   - CUDA_VER: "11.4.3"
     IMAGE_REPO: "citestwheel"
   - CUDA_VER: "11.4.3"
+    IMAGE_REPO: "ci-wheel"
+  - CUDA_VER: "12.1.1"
+    IMAGE_REPO: "citestwheel"
+  - CUDA_VER: "12.1.1"
     IMAGE_REPO: "ci-wheel"
 
   # exclude citestwheel for rockylinux8


### PR DESCRIPTION
This PR temporarily re-adds `12.1.1` to our matrix.

This is necessary so that we re-publish `12.1.1` images with the updated `sccache` version from #104.

The `12.1.1` images are still being used by the Morpheus team.