### PR TITLE
Revert "Temporarily re-add `12.1.1` (#106)"

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -2,7 +2,6 @@ CUDA_VER:
   - "11.4.3"
   - "11.8.0"
   - "12.0.1"
-  - "12.1.1"
   - "12.2.2"
 PYTHON_VER:
   - "3.9"
@@ -35,10 +34,6 @@ exclude:
   - CUDA_VER: "11.4.3"
     IMAGE_REPO: "citestwheel"
   - CUDA_VER: "11.4.3"
-    IMAGE_REPO: "ci-wheel"
-  - CUDA_VER: "12.1.1"
-    IMAGE_REPO: "citestwheel"
-  - CUDA_VER: "12.1.1"
     IMAGE_REPO: "ci-wheel"
 
   # exclude citestwheel for rockylinux8


### PR DESCRIPTION
This reverts commit 10334061e81ebb3a11b15a8cd81ca286185b3677.

This PR should be merged only after https://github.com/rapidsai/ci-imgs/actions/runs/7847033142 completes.