### PR TITLE
Add Ubuntu 22.04 citestwheel image

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -40,7 +40,7 @@ exclude:
   - LINUX_VER: "rockylinux8"
     IMAGE_REPO: "citestwheel"
 
-  # exclude citestwheel and ci-wheel for ubuntu22.04
+  # exclude ci-wheel for ubuntu22.04
   - LINUX_VER: "ubuntu22.04"
     IMAGE_REPO: "ci-wheel"
 

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -42,8 +42,6 @@ exclude:
 
   # exclude citestwheel and ci-wheel for ubuntu22.04
   - LINUX_VER: "ubuntu22.04"
-    IMAGE_REPO: "citestwheel"
-  - LINUX_VER: "ubuntu22.04"
     IMAGE_REPO: "ci-wheel"
 
   # exclude ci-conda for ubuntu18.04


### PR DESCRIPTION
Nightly wheel tests have been failing due to missing Ubuntu 22.04 image, removing the exclusion should probably resolve that.