### PR TITLE
Use CUDA 12.2 for latest tag.

### DIFF
--- a/latest.yaml
+++ b/latest.yaml
@@ -1,9 +1,9 @@
 # Define the values used for the "latest" tag
 conda:
-  CUDA_VER: "12.0.1"
+  CUDA_VER: "12.2.2"
   PYTHON_VER: "3.10"
   LINUX_VER: "ubuntu22.04"
 wheels:
-  CUDA_VER: "12.0.1"
+  CUDA_VER: "12.2.2"
   PYTHON_VER: "3.10"
   LINUX_VER: "ubuntu20.04"


### PR DESCRIPTION
This PR updates the "latest" tag to use CUDA 12.2 images.
