### PR TITLE
Add conda-merge to ci-conda images.

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -111,6 +111,7 @@ RUN <<EOF
 rapids-mamba-retry install -y \
   anaconda-client \
   boa \
+  conda-merge \
   gettext \
   gh \
   git \
@@ -152,7 +153,7 @@ RUN cat /tmp/condarc.tmpl | envsubst | tee /opt/conda/.condarc; \
 RUN /opt/conda/bin/git config --system --add safe.directory '*'
 
 # Install CI tools using pip
-RUN pip install conda-merge dunamai "rapids-dependency-file-generator==1.*" \
+RUN pip install dunamai "rapids-dependency-file-generator==1.*" \
     && pip cache purge
 
 COPY --from=mikefarah/yq:4.40.7 /usr/bin/yq /usr/local/bin/yq

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -152,7 +152,7 @@ RUN cat /tmp/condarc.tmpl | envsubst | tee /opt/conda/.condarc; \
 RUN /opt/conda/bin/git config --system --add safe.directory '*'
 
 # Install CI tools using pip
-RUN pip install dunamai "rapids-dependency-file-generator==1.*" \
+RUN pip install conda-merge dunamai "rapids-dependency-file-generator==1.*" \
     && pip cache purge
 
 COPY --from=mikefarah/yq:4.40.7 /usr/bin/yq /usr/local/bin/yq


### PR DESCRIPTION
I'm experimenting with a change to conda CI workflows that would install test dependencies and library packages at the same time, rather than creating an environment with `rapids-dependency-file-generator` containing only test dependencies and then later adding the library packages. See: https://github.com/rapidsai/cuml/pull/5781

To do this in the simplest way, I would like to add `conda-merge` to the `ci-conda` images. We can merge this change to CI images if the approach in the cuML PR seems like an improvement.