### PR TITLE
Update to rapids-dependency-file-generator v1.9.0

### DIFF
--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -185,7 +185,7 @@ EOF
 
 RUN <<EOF
 pyenv global ${PYTHON_VER}
-python -m pip install auditwheel patchelf twine rapids-dependency-file-generator dunamai
+python -m pip install auditwheel patchelf twine "rapids-dependency-file-generator==1.*" dunamai
 pyenv rehash
 EOF
 


### PR DESCRIPTION
This PR builds CI images with the latest rapids-dependency-file-generator. The change in this PR is small - it just makes the pinnings match between `ci-conda` and `ci-wheel`, but it'll fetch the latest version when rebuilding.