### PR TITLE
Revert "Use CUDA 12.2 for latest tag. (#111)"

### DIFF
--- a/latest.yaml
+++ b/latest.yaml
@@ -1,9 +1,9 @@
 # Define the values used for the "latest" tag
 conda:
-  CUDA_VER: "12.2.2"
+  CUDA_VER: "12.0.1"
   PYTHON_VER: "3.10"
   LINUX_VER: "ubuntu22.04"
 wheels:
-  CUDA_VER: "12.2.2"
+  CUDA_VER: "12.0.1"
   PYTHON_VER: "3.10"
   LINUX_VER: "ubuntu20.04"


### PR DESCRIPTION
This reverts commit d18dc4d59a0c2b5c3f251e90036fac9153cb785c.

PR #111 changes the `latest` configuration to use CUDA 12.2. This breaks workflows that require 12.0, and specifically affected hotfix workflows for branch-24.02 where CUDA 12.2 isn't supported. https://github.com/rapidsai/rapids-cmake/pull/542#issuecomment-1962005359

Reverting this change for now seems like the safest bet. We can re-evaluate in the future, once CUDA 12.2 is a safe default.