### PR TITLE
Reapply "Use CUDA 12.2 for latest tag"

### DIFF
--- a/latest.yaml
+++ b/latest.yaml
@@ -1,9 +1,9 @@
 # Define the values used for the "latest" tag
 conda:
-  CUDA_VER: "12.0.1"
+  CUDA_VER: "12.2.2"
   PYTHON_VER: "3.10"
   LINUX_VER: "ubuntu22.04"
 wheels:
-  CUDA_VER: "12.0.1"
+  CUDA_VER: "12.2.2"
   PYTHON_VER: "3.10"
   LINUX_VER: "ubuntu20.04"


### PR DESCRIPTION
Fixes https://github.com/rapidsai/build-planning/issues/6

This reverts commit https://github.com/rapidsai/ci-imgs/commit/37a8b8ba45245dfef6bb54ecf765f95b0fddea91

Thus this restores the original CUDA 12.2 changes

xref: https://github.com/rapidsai/ci-imgs/pull/111
xref: https://github.com/rapidsai/ci-imgs/pull/114