### PR TITLE
remove versioning specification in regex

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -8,5 +8,5 @@ CODECOV_VER: 0.3.2
 YQ_VER: 4.41.1
 # renovate: datasource=github-releases depName=openucx/ucx
 UCX_VER: 1.14.1
-# renovate: datasource=docker depName=amazon/aws-cli versioning=docker
+# renovate: datasource=docker depName=amazon/aws-cli
 AWS_CLI_VER: 2.15.9


### PR DESCRIPTION
Temporary remove versioning specification. Follow up PR will be open to fix regex as it currently does a greedy capture for `depName` as in `depName=(?<depName>[^\\n]+)` -- This incorrectly captures `versioning...` as part of `depName`.