### PR TITLE
Use Python 3.11 in latest tag.

### DIFF
--- a/latest.yaml
+++ b/latest.yaml
@@ -1,9 +1,9 @@
 # Define the values used for the "latest" tag
 conda:
   CUDA_VER: "12.0.1"
-  PYTHON_VER: "3.10"
+  PYTHON_VER: "3.11"
   LINUX_VER: "ubuntu22.04"
 wheels:
   CUDA_VER: "12.0.1"
-  PYTHON_VER: "3.10"
+  PYTHON_VER: "3.11"
   LINUX_VER: "ubuntu20.04"


### PR DESCRIPTION
Updates `latest` tag to use Python 3.11.

xref: https://github.com/rapidsai/build-planning/issues/3