### PR TITLE
Add `renovate` schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:base"],
+  "schedule": ["before 7am on the first day of the month"],
   "regexManagers": [
     {
       "fileMatch": "versions.yaml",


### PR DESCRIPTION
This PR configures `renovate` to run once per month on the first day of each month.

This will help eliminate excess GitHub notifications for dependencies that update frequently like the AWS CLI.

Scheduled updates will appear in the dependency dashboard issue below:

- https://github.com/rapidsai/ci-imgs/issues/14

From this dashboard, `renovate` can be triggered to open a PR for a particular dependency outside of the configured schedule.

Renovate has a great post below about noise reduction:

- https://docs.renovatebot.com/noise-reduction/