### PR TITLE
Install rapids-dependency-file-generator from Conda

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -106,6 +106,7 @@ RUN wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.ta
 # Install CI tools using mamba
 RUN <<EOF
 rapids-mamba-retry install -y \
+  -c rapidsai
   anaconda-client \
   boa \
   dunamai \

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -103,10 +103,16 @@ EOF
 RUN wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - \
   | tar -xz -C /usr/local/bin
 
+# Create condarc file from env vars
+ENV RAPIDS_CONDA_BLD_ROOT_DIR=/tmp/conda-bld-workspace
+ENV RAPIDS_CONDA_BLD_OUTPUT_DIR=/tmp/conda-bld-output
+COPY condarc.tmpl /tmp/condarc.tmpl
+RUN cat /tmp/condarc.tmpl | envsubst | tee /opt/conda/.condarc; \
+    rm -f /tmp/condarc.tmpl
+
 # Install CI tools using mamba
 RUN <<EOF
 rapids-mamba-retry install -y \
-  -c rapidsai \
   anaconda-client \
   boa \
   dunamai \
@@ -157,13 +163,6 @@ chmod +x codecov
 mv codecov /usr/local/bin
 rm -f codecov.SHA256SUM codecov.SHA256SUM.sig
 EOF
-
-# Create condarc file from env vars
-ENV RAPIDS_CONDA_BLD_ROOT_DIR=/tmp/conda-bld-workspace
-ENV RAPIDS_CONDA_BLD_OUTPUT_DIR=/tmp/conda-bld-output
-COPY condarc.tmpl /tmp/condarc.tmpl
-RUN cat /tmp/condarc.tmpl | envsubst | tee /opt/conda/.condarc; \
-    rm -f /tmp/condarc.tmpl
 
 RUN /opt/conda/bin/git config --system --add safe.directory '*'
 

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -108,6 +108,7 @@ RUN <<EOF
 rapids-mamba-retry install -y \
   anaconda-client \
   boa \
+  dunamai \
   gettext \
   git \
   jq \
@@ -164,10 +165,6 @@ RUN cat /tmp/condarc.tmpl | envsubst | tee /opt/conda/.condarc; \
     rm -f /tmp/condarc.tmpl
 
 RUN /opt/conda/bin/git config --system --add safe.directory '*'
-
-# Install CI tools using pip
-RUN pip install dunamai \
-    && pip cache purge
 
 COPY --from=yq /usr/bin/yq /usr/local/bin/yq
 COPY --from=aws-cli /usr/local/aws-cli/ /usr/local/aws-cli/

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -165,6 +165,10 @@ RUN cat /tmp/condarc.tmpl | envsubst | tee /opt/conda/.condarc; \
 
 RUN /opt/conda/bin/git config --system --add safe.directory '*'
 
+# Install CI tools using pip
+RUN pip install dunamai \
+    && pip cache purge
+
 COPY --from=yq /usr/bin/yq /usr/local/bin/yq
 COPY --from=aws-cli /usr/local/aws-cli/ /usr/local/aws-cli/
 COPY --from=aws-cli /usr/local/bin/ /usr/local/bin/

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -113,7 +113,7 @@ rapids-mamba-retry install -y \
   git \
   jq \
   "python=${PYTHON_VERSION}.*=*_cpython" \
-  rapids-dependency-file-generator
+  "rapids-dependency-file-generator==1.*"
 conda clean -aipty
 EOF
 

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -111,7 +111,8 @@ rapids-mamba-retry install -y \
   gettext \
   git \
   jq \
-  "python=${PYTHON_VERSION}.*=*_cpython"
+  "python=${PYTHON_VERSION}.*=*_cpython" \
+  rapids-dependency-file-generator
 conda clean -aipty
 EOF
 
@@ -163,10 +164,6 @@ RUN cat /tmp/condarc.tmpl | envsubst | tee /opt/conda/.condarc; \
     rm -f /tmp/condarc.tmpl
 
 RUN /opt/conda/bin/git config --system --add safe.directory '*'
-
-# Install CI tools using pip
-RUN pip install dunamai "rapids-dependency-file-generator==1.*" \
-    && pip cache purge
 
 COPY --from=yq /usr/bin/yq /usr/local/bin/yq
 COPY --from=aws-cli /usr/local/aws-cli/ /usr/local/aws-cli/

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -103,6 +103,13 @@ EOF
 RUN wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - \
   | tar -xz -C /usr/local/bin
 
+# Install prereq for envsubst
+RUN <<EOF
+rapids-mamba-retry install -y \
+  gettext
+conda clean -aipty
+EOF
+
 # Create condarc file from env vars
 ENV RAPIDS_CONDA_BLD_ROOT_DIR=/tmp/conda-bld-workspace
 ENV RAPIDS_CONDA_BLD_OUTPUT_DIR=/tmp/conda-bld-output
@@ -116,7 +123,6 @@ rapids-mamba-retry install -y \
   anaconda-client \
   boa \
   dunamai \
-  gettext \
   git \
   jq \
   "python=${PYTHON_VERSION}.*=*_cpython" \

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -106,7 +106,7 @@ RUN wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.ta
 # Install CI tools using mamba
 RUN <<EOF
 rapids-mamba-retry install -y \
-  -c rapidsai
+  -c rapidsai \
   anaconda-client \
   boa \
   dunamai \


### PR DESCRIPTION
Now that Conda packages are available for
`rapids-dependency-file-generator`, use those instead of the Pip packages.