### PR TITLE
Add Python 3.12

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -31,6 +31,7 @@ case "${LINUX_VER}" in
     apt-get update
     apt-get upgrade -y
     apt-get install -y --no-install-recommends \
+      curl \
       file \
       unzip \
       wget

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -7,6 +7,7 @@ PYTHON_VER:
   - "3.9"
   - "3.10"
   - "3.11"
+  - "3.12"
 LINUX_VER:
   - "ubuntu18.04"
   - "ubuntu20.04"


### PR DESCRIPTION
This PR adds Python 3.12 CI images. This is needed for `pynvjitlink`, though RAPIDS as a whole does not yet have a timeline/plan to add Python 3.12

Previously attempted here: https://github.com/rapidsai/ci-imgs/pull/96#issuecomment-1853051371

I think the previously seen errors may be resolved by now.
