### PR TITLE
Remove centos and ubuntu18.04 from ci-imgs matrix

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -57,6 +57,7 @@ jobs:
           LINUX_VER: ${{ inputs.LINUX_VER }}
           PYTHON_VER: ${{ inputs.PYTHON_VER }}
           ARCH: ${{ matrix.ARCH }}
+          IMAGE_REPO: ${{ inputs.IMAGE_REPO }}
       - name: Build image
         uses: docker/build-push-action@v5
         with:

--- a/ci/compute-build-args.sh
+++ b/ci/compute-build-args.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 MANYLINUX_VER="manylinux_2_17"
 if [[
-  "${LINUX_VER}" == "ubuntu18.04" ||
   "${LINUX_VER}" == "ubuntu20.04"
 ]]; then
   MANYLINUX_VER="manylinux_2_31"

--- a/ci/compute-build-args.sh
+++ b/ci/compute-build-args.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 set -euo pipefail
 
-MANYLINUX_VER="manylinux_2_17"
+if [[
+  "${IMAGE_REPO}" == "ci-wheel" &&
+  "${LINUX_VER}" != "ubuntu20.04" &&
+  "${LINUX_VER}" != "rockylinux8"
+]]; then
+  echo "Unsupported LINUX_VER: ${LINUX_VER} for ci-wheel image"
+  exit 1
+fi
+
+MANYLINUX_VER="manylinux_2_28"
 if [[
   "${LINUX_VER}" == "ubuntu20.04"
 ]]; then
   MANYLINUX_VER="manylinux_2_31"
-elif [[
-  "${LINUX_VER}" == "rockylinux8"
-]]; then
-  MANYLINUX_VER="manylinux_2_28"
 fi
 
 ARGS="

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -9,10 +9,8 @@ PYTHON_VER:
   - "3.11"
   - "3.12"
 LINUX_VER:
-  - "ubuntu18.04"
   - "ubuntu20.04"
   - "ubuntu22.04"
-  - "centos7"
   - "rockylinux8"
 IMAGE_REPO:
   - "ci-conda"
@@ -22,14 +20,6 @@ exclude:
   # Exclusions from CUDA's OS support matrix
   - LINUX_VER: "ubuntu22.04"
     CUDA_VER: "11.4.3"
-  - LINUX_VER: "ubuntu18.04"
-    CUDA_VER: "12.2.2"
-
-  # wheels:
-  - LINUX_VER: "ubuntu18.04"
-    IMAGE_REPO: "ci-wheel"
-  - LINUX_VER: "centos7"
-    IMAGE_REPO: "citestwheel"
 
   # exclude citestwheel and ci-wheel for cuda versions other than 11.8.0, 12.0.1, and 12.2.2
   - CUDA_VER: "11.4.3"
@@ -44,7 +34,3 @@ exclude:
   # exclude ci-wheel for ubuntu22.04
   - LINUX_VER: "ubuntu22.04"
     IMAGE_REPO: "ci-wheel"
-
-  # exclude ci-conda for ubuntu18.04
-  - LINUX_VER: "ubuntu18.04"
-    IMAGE_REPO: "ci-conda"


### PR DESCRIPTION
`centos7` and `ubuntu18.04` are no longer supported across RAPIDS starting from `24.06`. PR removes any combination referencing these from the images build matrix.

Also, as RAPIDS will no longer build `manylinux_2_17` tags for its wheels, this PR updates the `build-image` workflow accordingly.