### PR TITLE
Fix codecov uploader issue

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -152,11 +152,11 @@ EOF
 # Install codecov binary
 ARG CODECOV_VER
 RUN <<EOF
-curl https://uploader.codecov.io/verification.gpg --max-time 10 --retry 5 | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+curl https://keybase.io/codecovsecurity/pgp_keys.asc --max-time 10 --retry 5 | gpg --no-default-keyring --keyring trustedkeys.gpg --import
 
 case "${TARGETPLATFORM}" in
-  "linux/amd64") codecov_url="https://uploader.codecov.io/v${CODECOV_VER}/linux/codecov" ;;
-  "linux/arm64") codecov_url="https://uploader.codecov.io/v${CODECOV_VER}/aarch64/codecov" ;;
+  "linux/amd64") codecov_url="https://cli.codecov.io/v${CODECOV_VER}/linux/codecov" ;;
+  "linux/arm64") codecov_url="https://cli.codecov.io/v${CODECOV_VER}/linux-arm64/codecov" ;;
   *) echo 'Unsupported platform' && exit 1 ;;
 esac
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@ SCCACHE_VER: 0.7.7
 # renovate: datasource=github-releases depName=cli/cli
 GH_CLI_VER: 2.47.0
 # renovate: datasource=github-releases depName=codecov/uploader
-CODECOV_VER: 0.7.2
+CODECOV_VER: 0.6.0
 # renovate: datasource=docker depName=mikefarah/yq versioning=docker
 YQ_VER: 4.43.1
 # renovate: datasource=github-releases depName=openucx/ucx


### PR DESCRIPTION
This pull request aims to fix the codecov issue we have been experiencing.

Changes:

1. Everything looks set up correctly on the Github Codecov application side of things.
2. Transition from the old "Codecov Uploader" to the new "Codecov CLI" tool.
3. Usage of an organization-wide token for codecov.
4. The code in shared-workflows has been updated ([PR](https://github.com/rapidsai/shared-workflows/pull/212/files)) to reflect these changes.

Changes were tested in [this PR](https://github.com/rapidsai/literate-octo-potato/pull/826/files#diff-e8eaabca97ffb3e9eb2130977b2f056073e02c5a047e3ae6c3696f80e3d996ae). See job log [here](https://github.com/rapidsai/literate-octo-potato/actions/runs/9319362498/job/25653766086?pr=826#step:7:58). I tested the new `codecov_cli` by extending our `rapidsai/ci:latest` image and re-installing the new binary in the exact manner as is done [in this PR](https://github.com/rapidsai/ci-imgs/pull/141/files#diff-b46cd27f266243db6e7e8bba93fd5d5bcf76c4589a106138e9dfd62b50de2357L152-L172). The version is displayed in this [test log](https://github.com/rapidsai/literate-octo-potato/actions/runs/9319362498/job/25653766086?pr=826#step:7:47).

These changes _should_ rectify the rate-limiting issue we have been encountering during Codecov uploads.

cc: @raydouglass @bdice 