### PR TITLE
Revert "Fix codecov uploader issue"

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -152,11 +152,11 @@ EOF
 # Install codecov binary
 ARG CODECOV_VER
 RUN <<EOF
-curl https://keybase.io/codecovsecurity/pgp_keys.asc --max-time 10 --retry 5 | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+curl https://uploader.codecov.io/verification.gpg --max-time 10 --retry 5 | gpg --no-default-keyring --keyring trustedkeys.gpg --import
 
 case "${TARGETPLATFORM}" in
-  "linux/amd64") codecov_url="https://cli.codecov.io/v${CODECOV_VER}/linux/codecov" ;;
-  "linux/arm64") codecov_url="https://cli.codecov.io/v${CODECOV_VER}/linux-arm64/codecov" ;;
+  "linux/amd64") codecov_url="https://uploader.codecov.io/v${CODECOV_VER}/linux/codecov" ;;
+  "linux/arm64") codecov_url="https://uploader.codecov.io/v${CODECOV_VER}/aarch64/codecov" ;;
   *) echo 'Unsupported platform' && exit 1 ;;
 esac
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@ SCCACHE_VER: 0.7.7
 # renovate: datasource=github-releases depName=cli/cli
 GH_CLI_VER: 2.47.0
 # renovate: datasource=github-releases depName=codecov/uploader
-CODECOV_VER: 0.6.0
+CODECOV_VER: 0.7.2
 # renovate: datasource=docker depName=mikefarah/yq versioning=docker
 YQ_VER: 4.43.1
 # renovate: datasource=github-releases depName=openucx/ucx


### PR DESCRIPTION
Reverts rapidsai/ci-imgs#141 due to some CI errors seemingly having to do with GLIBC version required by the new `codecov_cli` tool in specific OS's such as Rocky Linux 8 and Ubuntu 20.04.

Slack thread: https://nvidia.slack.com/archives/CCE7L5XT3/p1717181327485959
Log: https://github.com/rapidsai/pynvjitlink/actions/runs/9322326958/job/25663358888?pr=81

```
Error loading Python lib '/tmp/_MEImwrRwT/libpython3.11.so.1.0': dlopen: /usr/lib/aarch64-linux-gnu/libm.so.6: version `GLIBC_2.35' not found (required by /tmp/_MEImwrRwT/libpython3.11.so.1.0)
```

