### PR TITLE
Use openssl main website

### DIFF
--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -70,7 +70,7 @@ case "${LINUX_VER}" in
       source scl_source enable devtoolset-11\n \
     ' > /etc/profile.d/enable_devtools.sh
     pushd tmp
-    wget https://ftp.openssl.org/source/openssl-1.1.1k.tar.gz
+    wget https://www.openssl.org/source/openssl-1.1.1k.tar.gz
     tar -xzvf openssl-1.1.1k.tar.gz
     cd openssl-1.1.1k
     ./config --prefix=/usr --openssldir=/etc/ssl --libdir=lib no-shared zlib-dynamic
@@ -97,7 +97,7 @@ case "${LINUX_VER}" in
       source /opt/rh/gcc-toolset-11/enable \
     ' > /etc/profile.d/enable_devtools.sh
     pushd tmp
-    wget https://ftp.openssl.org/source/openssl-1.1.1k.tar.gz
+    wget https://www.openssl.org/source/openssl-1.1.1k.tar.gz
         tar -xzvf openssl-1.1.1k.tar.gz
     cd openssl-1.1.1k
     ./config --prefix=/usr --openssldir=/etc/ssl --libdir=lib no-shared zlib-dynamic


### PR DESCRIPTION
Switches from `ftp.openssl.org` to `www.openssl.org` due to the ftp domain being no longer available.

Noticed in failed workflow runs
- ex: https://github.com/rapidsai/ci-imgs/actions/runs/9440665983/job/26000341012#step:8:2226