### PR TITLE
always consider pypi.nvidia.com in pip commands

### DIFF
--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -22,9 +22,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV RAPIDS_CUDA_VERSION="${CUDA_VER}"
 ENV RAPIDS_PY_VERSION="${PYTHON_VER}"
 
-# RAPIDS pip index
-ENV PIP_EXTRA_INDEX_URL="https://pypi.anaconda.org/rapidsai-wheels-nightly/simple"
-
 ENV PYENV_ROOT="/pyenv"
 ENV PATH="/pyenv/bin:/pyenv/shims:$PATH"
 

--- a/context/pip.conf
+++ b/context/pip.conf
@@ -1,3 +1,7 @@
 [global]
 quiet = 0
 verbose = 2
+
+extra-index-url =
+    https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
+    https://pypi.nvidia.com


### PR DESCRIPTION
Several nightly build jobs on the 24.06 release are failing right now ([build link](https://github.com/rapidsai/workflows/actions/runs/9442741547)), with errors like this

```text
urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1133)>
...
nvidia_stub.error.InstallFailedError
```

In short, this is because of the following mix of conditions:

* those builds are running `pip install` or similar and consider the following:
   - `pypi.org/simple` (public PyPI)
   - `pypi.anaconda.org/rapidsai-wheels-nightly/simple/` (RAPIDS nightlies)
* now that there are `24.6.0` versions on public PyPI, those are preferred to the nightlies because `24.6.0 > 24.6.0a{n}`
* those versions on public PyPI are sdists that use `nvidia-stub` ([link](https://pypi.org/project/nvidia-stub/)) to redirect to `pypi.nvidia.com`
* downloads from `pypi.nvidia.com` fail in the rockylinux8-based CI image (`rapidsai/ci-wheel`) because the root certificates on that operating system are too old

This proposes fixing that by adding configuration telling `pip` to always directly consider `pypi.nvidia.com`. From some experiments (e.g. https://github.com/rapidsai/cugraph/pull/4464), that seems to be enough to get `pip` to instead directly find the wheels on `pypi.nvidia.com`, avoiding the use of `nvidia-stub` completely.

## Notes for Reviewers

This problem only affects the rockylinux8-based images (`rapidsai/ci-wheel`).