### PR TITLE
Turn off -vv in pip

### DIFF
--- a/context/pip.conf
+++ b/context/pip.conf
@@ -1,6 +1,5 @@
 [global]
 quiet = 0
-verbose = 2
 
 extra-index-url =
     https://pypi.anaconda.org/rapidsai-wheels-nightly/simple


### PR DESCRIPTION
GitHub is now having trouble rendering logs this verbose. Turn `-vv` off.