### PR TITLE
remove ucx from wheel images

### DIFF
--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -133,31 +133,6 @@ EOF
 # Set AUDITWHEEL_* env vars for use with auditwheel
 ENV AUDITWHEEL_POLICY=${POLICY} AUDITWHEEL_ARCH=${REAL_ARCH} AUDITWHEEL_PLAT=${POLICY}_${REAL_ARCH}
 
-
-# Install ucx
-ARG UCX_VER=notset
-RUN <<EOF
-mkdir -p /ucx-src
-cd /ucx-src
-git clone https://github.com/openucx/ucx -b v${UCX_VER} ucx-git-repo
-cd ucx-git-repo
-./autogen.sh
-./contrib/configure-release \
-  --prefix=/usr               \
-  --enable-mt                 \
-  --enable-cma                \
-  --enable-numa               \
-  --with-gnu-ld               \
-  --with-sysroot              \
-  --without-verbs             \
-  --without-rdmacm            \
-  --with-cuda=/usr/local/cuda
-CPPFLAGS=-I/usr/local/cuda/include make -j
-make install
-cd /
-rm -rf /ucx-src/
-EOF
-
 # Install pyenv
 RUN curl https://pyenv.run | bash
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -6,7 +6,5 @@ GH_CLI_VER: 2.51.0
 CODECOV_VER: 0.7.1
 # renovate: datasource=docker depName=mikefarah/yq versioning=docker
 YQ_VER: 4.44.2
-# renovate: datasource=github-releases depName=openucx/ucx
-UCX_VER: 1.15.0
 # renovate: datasource=docker depName=amazon/aws-cli versioning=docker
 AWS_CLI_VER: 2.17.2


### PR DESCRIPTION
As a result of https://github.com/rapidsai/build-planning/issues/57, it should no longer be necessary to install openucx in the wheel images here.

Projects depending on UCX in their CI all now get it from either the `ucx` conda-forge package or the `libucx` wheels published from https://github.com/rapidsai/ucx-wheels.

This proposes removing UCX builds in the wheel images. Benefits of that:

* reduces build times and complexity
* allows for some simplifications to CI in `ucx-py` and `ucxx` (e.g. https://github.com/rapidsai/ucxx/pull/226#discussion_r1583657525)
