### PR TITLE
Install rapids-dependency-file-generator in test-wheel image

### DIFF
--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -56,6 +56,10 @@ ENV PATH="/pyenv/versions/${PYTHON_VER}/bin/:$PATH"
 COPY --from=aws-cli /usr/local/aws-cli/ /usr/local/aws-cli/
 COPY --from=aws-cli /usr/local/bin/ /usr/local/bin/
 
+# Install rapids-dependency-file-generator
+RUN pyenv global ${PYTHON_VER} && python -m pip install rapids-dependency-file-generator \
+  && pyenv rehash
+
 # Install latest gha-tools
 RUN wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - \
   | tar -xz -C /usr/local/bin

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -57,7 +57,7 @@ COPY --from=aws-cli /usr/local/aws-cli/ /usr/local/aws-cli/
 COPY --from=aws-cli /usr/local/bin/ /usr/local/bin/
 
 # Install rapids-dependency-file-generator
-RUN pyenv global ${PYTHON_VER} && python -m pip install rapids-dependency-file-generator \
+RUN pyenv global ${PYTHON_VER} && python -m pip install 'rapids-dependency-file-generator>=1.14.0,<2.0.0a0' \
   && pyenv rehash
 
 # Install latest gha-tools


### PR DESCRIPTION
To allow testing the oldest dependencies, we wish to encode these into the `dependencies.yaml` file.  To generate them at test time we then need `rapids-dependency-file-generator` to be installed and it seems easier to do this here.

xref https://github.com/rapidsai/build-planning/issues/81

*NOTE: I haven't tested this locally yet, the README snippet didn't run right away for me adding the equivalent [here](https://github.com/rapidsai/rmm/pull/1613/files#diff-65e357e2da7e1573d93ff3794f8846d2517c42004ebc5aa5dafc1e4d02105559R15) worked and the build log looks right*