### PR TITLE
stop automatically recommending sccache updates

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,6 @@
-# renovate: datasource=github-releases depName=mozilla/sccache
+# 'sccache' is intentionally not auto-updated by renovate. Such updates
+# have the potential to significantly disrupt RAPIDS development, so we
+# prefer sticking with a stable version until a specific reason to update arises.
 SCCACHE_VER: 0.7.7
 # renovate: datasource=github-releases depName=cli/cli
 GH_CLI_VER: 2.54.0


### PR DESCRIPTION
Replaces #144 

Based on an offline conversation with @trxcllnt . `sccache` updates have such a high potential to disrupt development in RAPIDS, I think we should only update to a new version manually and based on some specific need (getting a known new feature, upgrading past a known bug, etc.).

This proposes that change.