### PR TITLE
update pip in wheel images on every rebuild

### DIFF
--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -181,6 +181,7 @@ EOF
 
 RUN <<EOF
 pyenv global ${PYTHON_VER}
+python -m pip install --upgrade pip
 python -m pip install auditwheel patchelf twine "rapids-dependency-file-generator==1.*" dunamai
 pyenv rehash
 EOF

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -56,9 +56,13 @@ ENV PATH="/pyenv/versions/${PYTHON_VER}/bin/:$PATH"
 COPY --from=aws-cli /usr/local/aws-cli/ /usr/local/aws-cli/
 COPY --from=aws-cli /usr/local/bin/ /usr/local/bin/
 
-# Install rapids-dependency-file-generator
-RUN pyenv global ${PYTHON_VER} && python -m pip install 'rapids-dependency-file-generator>=1.14.0,<2.0.0a0' \
-  && pyenv rehash
+# update pip and install build tools
+RUN <<EOF
+pyenv global ${PYTHON_VER}
+python -m pip install --upgrade pip
+python -m pip install "rapids-dependency-file-generator==1.*"
+pyenv rehash
+EOF
 
 # Install latest gha-tools
 RUN wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - \


### PR DESCRIPTION
Proposes updating to the latest `pip` in wheel images every time images are rebuilt here.

Proposing this based on this recent experience I had: https://github.com/rapidsai/cudf/pull/16575#discussion_r1720295828

There, I observed different behavior on otherwise-identical tests jobs because the version of `pip` in one of the wheel-testing images was a full minor version ahead of the version in another wheel-testing image (where both only differed by Python version).

```shell
docker run rapidsai/citestwheel:cuda12.5.1-ubuntu22.04-py3.10 pip --version
# pip 23.0.1

docker run rapidsai/citestwheel:cuda12.5.1-ubuntu22.04-py3.11 pip --version 
# pip 24.0
```

## Benefits of these changes

* fewer differences between CI jobs that only differ by Python version
* reduced risk of situations like https://github.com/rapidsai/cudf/pull/16575#discussion_r1720295828, where development time is spent investigating issues that have already been fixed in newer `pip` releases
* smaller changeset to consider when new `pip` release result in issues for RAPIDS projects
* increased confidence that RAPIDS wheels can be installed with the latest release of `pip`

## Costs of this change

* elevated risk of releasing libraries that can't be installed with older versions of `pip`
   - via losing some CI coverage using older `pip` versions