### PR TITLE
Enable `conda-build` to produce `.conda` packages

### DIFF
--- a/context/condarc.tmpl
+++ b/context/condarc.tmpl
@@ -7,6 +7,7 @@ channels:
   - conda-forge
   - nvidia
 conda-build:
+  pkg_format: '2'
   set_build_id: false
   root_dir: $RAPIDS_CONDA_BLD_ROOT_DIR
   output_folder: $RAPIDS_CONDA_BLD_OUTPUT_DIR


### PR DESCRIPTION
Fixes https://github.com/rapidsai/build-planning/issues/98

Switch from `.tar.bz2` packages to `.conda` packages. This will allow the metadata of packages to be read without decompression. Also `.conda` packages allow changing the compression used under-the-hood (currently this is Zstd based).