### PR TITLE
Add Rocky Linux 8 citestwheel images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ export LINUX_VER=ubuntu22.04
 export CUDA_VER=12.2.2
 export PYTHON_VER=3.11
 export ARCH=amd64
+export IMAGE_REPO=ci-conda
 docker build $(ci/compute-build-args.sh) -f ci-conda.Dockerfile context/
+export IMAGE_REPO=ci-wheel
 docker build $(ci/compute-build-args.sh) -f ci-wheel.Dockerfile context/
+export IMAGE_REPO=citestwheel
 docker build $(ci/compute-build-args.sh) -f citestwheel.Dockerfile context/
 ```
 

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -36,10 +36,6 @@ exclude:
   - CUDA_VER: "11.4.3"
     IMAGE_REPO: "ci-wheel"
 
-  # exclude citestwheel for rockylinux8
-  - LINUX_VER: "rockylinux8"
-    IMAGE_REPO: "citestwheel"
-
   # exclude ci-wheel for ubuntu22.04
   - LINUX_VER: "ubuntu22.04"
     IMAGE_REPO: "ci-wheel"


### PR DESCRIPTION
This adds Rocky Linux 8 citestwheel images. We would like to test wheels on Rocky Linux 8 because it has glibc 2.28, which should give us more confidence about the functionality of our manylinux 2.28 wheels.
