### PR TITLE
Don't build aws-sdk-cpp

### DIFF
--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -91,26 +91,6 @@ mv gh_*/bin/gh /usr/local/bin
 rm -rf gh_*
 EOF
 
-# Download, build, and install aws-sdk-cpp
-ARG AWS_SDK_CPP_VER=notset
-RUN <<EOF
-pushd tmp
-git clone --recurse-submodules -b ${AWS_SDK_CPP_VER} https://github.com/aws/aws-sdk-cpp.git
-cd aws-sdk-cpp
-cmake \
-  -S . \
-  -B build \
-  -DCMAKE_INSTALL_PREFIX=/usr/local \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DBUILD_ONLY=s3 \
-  -DBUILD_SHARED_LIBS=OFF \
-  -DENABLE_TESTING=OFF \
-  -DENABLE_UNITY_BUILD=ON
-cmake --build build/
-cmake --install build/
-popd
-EOF
-
 # Install sccache
 ARG SCCACHE_VER=notset
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -10,5 +10,3 @@ CODECOV_VER: 0.7.3
 YQ_VER: 4.44.2
 # renovate: datasource=docker depName=amazon/aws-cli versioning=docker
 AWS_CLI_VER: 2.17.20
-# renovate: datasource=github-releases depName=aws/aws-sdk-cpp
-AWS_SDK_CPP_VER: 1.11.384


### PR DESCRIPTION
We have decided to get `aws-sdk-cpp` through CPM instead of baking it into the base image. Remove the `aws-sdk-cpp` build. Keep the `libcurl` dependency so that `aws-sdk-cpp` can still be built in the individual CI runs.