### PR TITLE
ci-conda: update environment earlier

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -38,6 +38,19 @@ if [[ "$LINUX_VER" == "rockylinux"* ]]; then
 fi
 find /opt/conda -follow -type f -name '*.a' -delete
 find /opt/conda -follow -type f -name '*.pyc' -delete
+# Recreate missing libstdc++ symlinks.
+# This should be removed when it is fixed upstream.
+# ref: https://github.com/rapidsai/ci-imgs/issues/185
+if [[ ! -e "/opt/conda/lib/libstdc++.so.6" ]]; then
+    ln -sf \
+        "$(ls /opt/conda/lib/libstdc++.so.6.* | head -1)" \
+        /opt/conda/lib/libstdc++.so.6
+fi
+if [[ ! -e "/opt/conda/lib/libstdc++.so" ]]; then
+    ln -sf \
+        "$(ls /opt/conda/lib/libstdc++.so.6.* | head -1)" \
+        /opt/conda/lib/libstdc++.so
+fi
 conda clean -afy
 EOF
 

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -30,7 +30,7 @@ RUN <<EOF
 # Ensure new files/dirs have group write permissions
 umask 002
 # update everything before other environment changes, to ensure mixing
-# and older conda with newer packages still works well
+# an older conda with newer packages still works well
 conda update --all -y -n base
 # install expected Python version
 conda install -y -n base "python~=${PYTHON_VERSION}.0=*_cpython"

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -29,6 +29,9 @@ RUN chmod g+ws /opt/conda
 RUN <<EOF
 # Ensure new files/dirs have group write permissions
 umask 002
+# update everything before other environment changes, to ensure mixing
+# and older conda with newer packages still works well
+conda update --all -y -n base
 # install expected Python version
 conda install -y -n base "python~=${PYTHON_VERSION}.0=*_cpython"
 conda update --all -y -n base
@@ -38,19 +41,6 @@ if [[ "$LINUX_VER" == "rockylinux"* ]]; then
 fi
 find /opt/conda -follow -type f -name '*.a' -delete
 find /opt/conda -follow -type f -name '*.pyc' -delete
-# Recreate missing libstdc++ symlinks.
-# This should be removed when it is fixed upstream.
-# ref: https://github.com/rapidsai/ci-imgs/issues/185
-if [[ ! -e "/opt/conda/lib/libstdc++.so.6" ]]; then
-    ln -sf \
-        "$(ls /opt/conda/lib/libstdc++.so.6.* | head -1)" \
-        /opt/conda/lib/libstdc++.so.6
-fi
-if [[ ! -e "/opt/conda/lib/libstdc++.so" ]]; then
-    ln -sf \
-        "$(ls /opt/conda/lib/libstdc++.so.6.* | head -1)" \
-        /opt/conda/lib/libstdc++.so
-fi
 conda clean -afy
 EOF
 


### PR DESCRIPTION
Fixes #185

https://github.com/rapidsai/ci-imgs/issues/185#issuecomment-2327478322 has MUCH more detail, but in short:

* the way we build `ci-conda` images results in symlinks from `libdstc++.so` to the fully-qualified `libstdc++.so.6.0.33` (or similar) being destroyed
* that results in the system `libdstc++` being used instead of conda's
* that results in issues about missing GLIBCXX symbols (in the case where the system one is older than the one used at build time for libraries conda wants to load)

~**This PR is a hack to unblock CI**... by manually recreating those symlinks where necessary.~

Updated this to @vyasr 's suggestion from https://github.com/rapidsai/ci-imgs/issues/185#issuecomment-2327725065