### PR TITLE
update 'latest' tags to Python 3.12 images

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ The `latest` image tags are controlled by the values in `latest.yaml`.
 
 ## Building the dockerfiles locally
 
-To easily build the dockerfiles locally, you may use the following snippets:
+To build the dockerfiles locally, you may use the following snippets:
 
 ```sh
 export LINUX_VER=ubuntu22.04
-export CUDA_VER=12.2.2
-export PYTHON_VER=3.11
+export CUDA_VER=12.5.1
+export PYTHON_VER=3.12
 export ARCH=amd64
 export IMAGE_REPO=ci-conda
 docker build $(ci/compute-build-args.sh) -f ci-conda.Dockerfile context/
@@ -35,5 +35,5 @@ then pushes them on to the individual repos like `rapidsai/base`, `rapidsai/note
 A scheduled job regularly deletes old images from that `rapidsai/staging` repo.
 See https://github.com/rapidsai/workflows/blob/main/.github/workflows/cleanup_staging.yaml for details.
 
-If you come back to a pull requests here after more than a few days and find that jobs are failing with errors
+If you come back to a pull request here after more than a few days and find that jobs are failing with errors
 that suggest that some necessary images don't exist, re-run all of CI on that pull request to produce new images.

--- a/latest.yaml
+++ b/latest.yaml
@@ -1,18 +1,18 @@
 # Define the values used for the "latest" tag
 miniforge-cuda:
   CUDA_VER: "12.5.1"
-  PYTHON_VER: "3.11"
+  PYTHON_VER: "3.12"
   LINUX_VER: "ubuntu22.04"
 ci-conda:
   CUDA_VER: "12.5.1"
-  PYTHON_VER: "3.11"
+  PYTHON_VER: "3.12"
   LINUX_VER: "ubuntu22.04"
 ci-wheel:
   CUDA_VER: "12.5.1"
-  PYTHON_VER: "3.11"
+  PYTHON_VER: "3.12"
   # Wheels should always be built with the oldest supported glibc version
   LINUX_VER: "rockylinux8"
 citestwheel:
   CUDA_VER: "12.5.1"
-  PYTHON_VER: "3.11"
+  PYTHON_VER: "3.12"
   LINUX_VER: "ubuntu22.04"


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/40

Ensures that the images tagged `:latest` here use Python 3.12. Also suggests some small changes to the project's docs.