### PR TITLE
add telemetry installs to ci-conda and ci-wheel

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -231,8 +231,6 @@ dpkg -i otel-cli-${CPU_ARCH}.deb
 git clone -b add-conda-build-instrumentation https://github.com/msarahan/opentelemetry-python-contrib
 pip install -e ./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-conda-build
 opentelemetry-bootstrap -a install
-            git clone https://github.com/msarahan/gha-tools.git -b main /tmp/gha-tools
-            echo "/tmp/gha-tools/tools" >> "${GITHUB_PATH}"
 EOF
 
 

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -223,7 +223,18 @@ wget https://github.com/cli/cli/releases/download/v${GH_CLI_VER}/gh_${GH_CLI_VER
 tar -xf gh_*.tar.gz
 mv gh_*/bin/gh /usr/local/bin
 rm -rf gh_*
+
+# Install OpenTelemetry instrumentation
+pip install opentelemetry-distro[otlp] opentelemetry-exporter-prometheus
+curl -L -o otel-cli-${CPU_ARCH}.deb https://github.com/equinix-labs/otel-cli/releases/download/v0.4.5/otel-cli_0.4.5_linux_${CPU_ARCH}.deb
+dpkg -i otel-cli-${CPU_ARCH}.deb
+git clone -b add-conda-build-instrumentation https://github.com/msarahan/opentelemetry-python-contrib
+pip install -e ./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-conda-build
+opentelemetry-bootstrap -a install
+            git clone https://github.com/msarahan/gha-tools.git -b main /tmp/gha-tools
+            echo "/tmp/gha-tools/tools" >> "${GITHUB_PATH}"
 EOF
+
 
 # Install codecov from source distribution
 ARG CODECOV_VER=notset

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -226,8 +226,8 @@ rm -rf gh_*
 
 # Install OpenTelemetry instrumentation
 pip install opentelemetry-distro[otlp] opentelemetry-exporter-prometheus
-curl -L -o otel-cli-${ CPU_ARCH }.tar.gz https://github.com/equinix-labs/otel-cli/releases/download/v0.4.5/otel-cli_0.4.5_linux_${ CPU_ARCH }.tar.gz
-tar -zxf  otel-cli-${ CPU_ARCH }.tar.gz
+curl -L -o "otel-cli-${CPU_ARCH}.tar.gz" https://github.com/equinix-labs/otel-cli/releases/download/v0.4.5/otel-cli_0.4.5_linux_${CPU_ARCH}.tar.gz
+tar -zxf  "otel-cli-${CPU_ARCH}.tar.gz"
 mv otel-cli /usr/local/bin/
 git clone -b add-conda-build-instrumentation https://github.com/msarahan/opentelemetry-python-contrib
 pip install -e ./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-conda-build

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -226,8 +226,8 @@ rm -rf gh_*
 
 # Install OpenTelemetry instrumentation
 pip install opentelemetry-distro[otlp] opentelemetry-exporter-prometheus
-curl -L -o otel-cli-${{ CPU_ARCH }}.tar.gz https://github.com/equinix-labs/otel-cli/releases/download/v0.4.5/otel-cli_0.4.5_linux_${{ CPU_ARCH }}.tar.gz
-tar -zxf  otel-cli-${{ CPU_ARCH }}.tar.gz
+curl -L -o otel-cli-${ CPU_ARCH }.tar.gz https://github.com/equinix-labs/otel-cli/releases/download/v0.4.5/otel-cli_0.4.5_linux_${ CPU_ARCH }.tar.gz
+tar -zxf  otel-cli-${ CPU_ARCH }.tar.gz
 mv otel-cli /usr/local/bin/
 git clone -b add-conda-build-instrumentation https://github.com/msarahan/opentelemetry-python-contrib
 pip install -e ./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-conda-build

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -236,12 +236,11 @@ rm -rf gh_*
 
 # Install OpenTelemetry instrumentation
 pip install opentelemetry-distro[otlp] opentelemetry-exporter-prometheus
+opentelemetry-bootstrap -a install
 curl -L -o "otel-cli-${CPU_ARCH}.tar.gz" https://github.com/equinix-labs/otel-cli/releases/download/v0.4.5/otel-cli_0.4.5_linux_${CPU_ARCH}.tar.gz
 tar -zxf  "otel-cli-${CPU_ARCH}.tar.gz"
 mv otel-cli /usr/local/bin/
-git clone -b add-conda-build-instrumentation https://github.com/msarahan/opentelemetry-python-contrib
-pip install -e ./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-conda-build
-opentelemetry-bootstrap -a install
+rm -rf "otel-cli-${CPU_ARCH}.tar.gz"
 EOF
 
 

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -226,8 +226,9 @@ rm -rf gh_*
 
 # Install OpenTelemetry instrumentation
 pip install opentelemetry-distro[otlp] opentelemetry-exporter-prometheus
-curl -L -o otel-cli-${CPU_ARCH}.deb https://github.com/equinix-labs/otel-cli/releases/download/v0.4.5/otel-cli_0.4.5_linux_${CPU_ARCH}.deb
-dpkg -i otel-cli-${CPU_ARCH}.deb
+curl -L -o otel-cli-${{ CPU_ARCH }}.tar.gz https://github.com/equinix-labs/otel-cli/releases/download/v0.4.5/otel-cli_0.4.5_linux_${{ CPU_ARCH }}.tar.gz
+tar -zxf  otel-cli-${{ CPU_ARCH }}.tar.gz
+mv otel-cli /usr/local/bin/
 git clone -b add-conda-build-instrumentation https://github.com/msarahan/opentelemetry-python-contrib
 pip install -e ./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-conda-build
 opentelemetry-bootstrap -a install

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -158,8 +158,9 @@ COPY pip.conf /etc/xdg/pip/pip.conf
 RUN <<EOF
 # Install OpenTelemetry instrumentation
 pip install opentelemetry-distro[otlp] opentelemetry-exporter-prometheus
-curl -L -o otel-cli-${CPU_ARCH}.deb https://github.com/equinix-labs/otel-cli/releases/download/v0.4.5/otel-cli_0.4.5_linux_${CPU_ARCH}.deb
-dpkg -i otel-cli-${CPU_ARCH}.deb
+curl -L -o otel-cli-${{ matrix.ARCH }}.tar.gz https://github.com/equinix-labs/otel-cli/releases/download/v0.4.5/otel-cli_0.4.5_linux_${{ matrix.ARCH }}.tar.gz
+tar -zxf  otel-cli-${{ matrix.ARCH }}.tar.gz
+mv otel-cli /usr/local/bin/
 git clone -b add-conda-build-instrumentation https://github.com/msarahan/opentelemetry-python-contrib
 pip install -e ./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-conda-build
 opentelemetry-bootstrap -a install

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -155,4 +155,16 @@ RUN git config --system --add safe.directory '*'
 # Add pip.conf
 COPY pip.conf /etc/xdg/pip/pip.conf
 
+RUN <<EOF
+# Install OpenTelemetry instrumentation
+pip install opentelemetry-distro[otlp] opentelemetry-exporter-prometheus
+curl -L -o otel-cli-${CPU_ARCH}.deb https://github.com/equinix-labs/otel-cli/releases/download/v0.4.5/otel-cli_0.4.5_linux_${CPU_ARCH}.deb
+dpkg -i otel-cli-${CPU_ARCH}.deb
+git clone -b add-conda-build-instrumentation https://github.com/msarahan/opentelemetry-python-contrib
+pip install -e ./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-conda-build
+opentelemetry-bootstrap -a install
+            git clone https://github.com/msarahan/gha-tools.git -b main /tmp/gha-tools
+            echo "/tmp/gha-tools/tools" >> "${GITHUB_PATH}"
+EOF
+
 CMD ["/bin/bash"]

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -163,8 +163,6 @@ dpkg -i otel-cli-${CPU_ARCH}.deb
 git clone -b add-conda-build-instrumentation https://github.com/msarahan/opentelemetry-python-contrib
 pip install -e ./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-conda-build
 opentelemetry-bootstrap -a install
-            git clone https://github.com/msarahan/gha-tools.git -b main /tmp/gha-tools
-            echo "/tmp/gha-tools/tools" >> "${GITHUB_PATH}"
 EOF
 
 CMD ["/bin/bash"]

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -165,12 +165,11 @@ COPY pip.conf /etc/xdg/pip/pip.conf
 RUN <<EOF
 # Install OpenTelemetry instrumentation
 pip install opentelemetry-distro[otlp] opentelemetry-exporter-prometheus
+opentelemetry-bootstrap -a install
 curl -L -o "otel-cli-${CPU_ARCH}.tar.gz" https://github.com/equinix-labs/otel-cli/releases/download/v0.4.5/otel-cli_0.4.5_linux_${CPU_ARCH}.tar.gz
 tar -zxf  "otel-cli-${CPU_ARCH}.tar.gz"
 mv otel-cli /usr/local/bin/
-git clone -b add-conda-build-instrumentation https://github.com/msarahan/opentelemetry-python-contrib
-pip install -e ./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-conda-build
-opentelemetry-bootstrap -a install
+rm -rf  "otel-cli-${CPU_ARCH}.tar.gz"
 EOF
 
 CMD ["/bin/bash"]

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -158,8 +158,8 @@ COPY pip.conf /etc/xdg/pip/pip.conf
 RUN <<EOF
 # Install OpenTelemetry instrumentation
 pip install opentelemetry-distro[otlp] opentelemetry-exporter-prometheus
-curl -L -o otel-cli-${ CPU_ARCH }.tar.gz https://github.com/equinix-labs/otel-cli/releases/download/v0.4.5/otel-cli_0.4.5_linux_${ CPU_ARCH }.tar.gz
-tar -zxf  otel-cli-${ CPU_ARCH }.tar.gz
+curl -L -o "otel-cli-${CPU_ARCH}.tar.gz" https://github.com/equinix-labs/otel-cli/releases/download/v0.4.5/otel-cli_0.4.5_linux_${CPU_ARCH}.tar.gz
+tar -zxf  "otel-cli-${CPU_ARCH}.tar.gz"
 mv otel-cli /usr/local/bin/
 git clone -b add-conda-build-instrumentation https://github.com/msarahan/opentelemetry-python-contrib
 pip install -e ./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-conda-build

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -158,8 +158,8 @@ COPY pip.conf /etc/xdg/pip/pip.conf
 RUN <<EOF
 # Install OpenTelemetry instrumentation
 pip install opentelemetry-distro[otlp] opentelemetry-exporter-prometheus
-curl -L -o otel-cli-${{ matrix.ARCH }}.tar.gz https://github.com/equinix-labs/otel-cli/releases/download/v0.4.5/otel-cli_0.4.5_linux_${{ matrix.ARCH }}.tar.gz
-tar -zxf  otel-cli-${{ matrix.ARCH }}.tar.gz
+curl -L -o otel-cli-${ CPU_ARCH }.tar.gz https://github.com/equinix-labs/otel-cli/releases/download/v0.4.5/otel-cli_0.4.5_linux_${ CPU_ARCH }.tar.gz
+tar -zxf  otel-cli-${ CPU_ARCH }.tar.gz
 mv otel-cli /usr/local/bin/
 git clone -b add-conda-build-instrumentation https://github.com/msarahan/opentelemetry-python-contrib
 pip install -e ./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-conda-build

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -11,6 +11,7 @@ FROM ${BASE_IMAGE}
 ARG CUDA_VER=notset
 ARG LINUX_VER=notset
 ARG PYTHON_VER=notset
+ARG CPU_ARCH=notset
 
 # Set RAPIDS versions env variables
 ENV RAPIDS_CUDA_VERSION="${CUDA_VER}"
@@ -89,6 +90,17 @@ pyenv global ${PYTHON_VER}
 python -m pip install --upgrade pip
 python -m pip install "rapids-dependency-file-generator==1.*"
 pyenv rehash
+EOF
+
+RUN <<EOF
+# Install OpenTelemetry instrumentation
+pip install opentelemetry-distro[otlp] opentelemetry-exporter-prometheus
+curl -L -o "otel-cli-${CPU_ARCH}.tar.gz" https://github.com/equinix-labs/otel-cli/releases/download/v0.4.5/otel-cli_0.4.5_linux_${CPU_ARCH}.tar.gz
+tar -zxf  "otel-cli-${CPU_ARCH}.tar.gz"
+mv otel-cli /usr/local/bin/
+git clone -b add-conda-build-instrumentation https://github.com/msarahan/opentelemetry-python-contrib
+pip install -e ./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-conda-build
+opentelemetry-bootstrap -a install
 EOF
 
 # Install latest gha-tools

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -107,12 +107,11 @@ EOF
 RUN <<EOF
 # Install OpenTelemetry instrumentation
 pip install opentelemetry-distro[otlp] opentelemetry-exporter-prometheus
+opentelemetry-bootstrap -a install
 curl -L -o "otel-cli-${CPU_ARCH}.tar.gz" https://github.com/equinix-labs/otel-cli/releases/download/v0.4.5/otel-cli_0.4.5_linux_${CPU_ARCH}.tar.gz
 tar -zxf  "otel-cli-${CPU_ARCH}.tar.gz"
 mv otel-cli /usr/local/bin/
-git clone -b add-conda-build-instrumentation https://github.com/msarahan/opentelemetry-python-contrib
-pip install -e ./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-conda-build
-opentelemetry-bootstrap -a install
+rm -rf  "otel-cli-${CPU_ARCH}.tar.gz"
 EOF
 
 # Install latest gha-tools


### PR DESCRIPTION
This is a work in progress; part of https://github.com/rapidsai/build-infra/issues/139. Right now, these installs are being done in workflow scripts, like https://github.com/rapidsai/shared-workflows/blob/add-telemetry/.github/workflows/conda-cpp-build.yaml#L124.