### PR TITLE
Add conda-package-handling.

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -198,6 +198,7 @@ RUN <<EOF
 rapids-mamba-retry install -y \
   anaconda-client \
   boa \
+  conda-package-handling \
   dunamai \
   git \
   jq \

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -131,7 +131,13 @@ EOF
 RUN <<EOF
 pyenv global ${PYTHON_VER}
 python -m pip install --upgrade pip
-python -m pip install auditwheel patchelf twine "rapids-dependency-file-generator==1.*" dunamai
+python -m pip install \
+  auditwheel \
+  conda-package-handling \
+  dunamai \
+  patchelf \
+  "rapids-dependency-file-generator==1.*" \
+  twine
 pyenv rehash
 EOF
 


### PR DESCRIPTION
We need `cph` (`conda-package-handling` CLI tool) in the `ci-conda` and `ci-wheel` base environments, to help extract `.conda` packages.

xref: https://github.com/rapidsai/shared-workflows/issues/250
xref: https://github.com/rapidsai/ci-imgs/pull/176
