### PR TITLE
Add tzdata-legacy to Ubuntu 24.04 images

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -56,13 +56,21 @@ echo ". /opt/conda/etc/profile.d/conda.sh; conda activate base" >> ~/.bashrc
 EOF
 
 # tzdata is needed by the ORC library used by pyarrow, because it provides /etc/localtime
+# On Ubuntu 24.04 and newer, we also need tzdata-legacy
 RUN <<EOF
 case "${LINUX_VER}" in
   "ubuntu"*)
+    os_version=$(grep 'VERSION_ID' /etc/os-release | cut -d '"' -f 2)
+    if [[ "${os_version}" > "24.04" ]] || [[ "${os_version}" == "24.04" ]]; }; then
+        tzdata_pkgs="tzdata tzdata-legacy"
+    else
+        tzdata_pkgs="tzdata"
+    fi
+
     apt-get update
     apt-get upgrade -y
     apt-get install -y --no-install-recommends \
-      tzdata
+      ${tzdata_pkgs}
     rm -rf "/var/lib/apt/lists/*"
     ;;
   "rockylinux"*)

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -61,7 +61,7 @@ RUN <<EOF
 case "${LINUX_VER}" in
   "ubuntu"*)
     os_version=$(grep 'VERSION_ID' /etc/os-release | cut -d '"' -f 2)
-    if [[ "${os_version}" > "24.04" ]] || [[ "${os_version}" == "24.04" ]]; }; then
+    if [[ "${os_version}" > "24.04" ]] || [[ "${os_version}" == "24.04" ]]; then
         tzdata_pkgs="tzdata tzdata-legacy"
     else
         tzdata_pkgs="tzdata"

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -62,15 +62,15 @@ case "${LINUX_VER}" in
   "ubuntu"*)
     os_version=$(grep 'VERSION_ID' /etc/os-release | cut -d '"' -f 2)
     if [[ "${os_version}" > "24.04" ]] || [[ "${os_version}" == "24.04" ]]; then
-        tzdata_pkgs="tzdata tzdata-legacy"
+        tzdata_pkgs=(tzdata tzdata-legacy)
     else
-        tzdata_pkgs="tzdata"
+        tzdata_pkgs=(tzdata)
     fi
 
     apt-get update
     apt-get upgrade -y
     apt-get install -y --no-install-recommends \
-      ${tzdata_pkgs}
+      "${tzdata_pkgs[@]}"
     rm -rf "/var/lib/apt/lists/*"
     ;;
   "rockylinux"*)

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -39,7 +39,7 @@ case "${LINUX_VER}" in
     # tzdata is needed by the ORC library used by pyarrow, because it provides /etc/localtime
     # On Ubuntu 24.04 and newer, we also need tzdata-legacy
     os_version=$(grep 'VERSION_ID' /etc/os-release | cut -d '"' -f 2)
-    if [[ "${os_version}" > "24.04" ]] || [[ "${os_version}" == "24.04" ]]; }; then
+    if [[ "${os_version}" > "24.04" ]] || [[ "${os_version}" == "24.04" ]]; then
         tzdata_pkgs="tzdata tzdata-legacy"
     else
         tzdata_pkgs="tzdata"

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -35,12 +35,23 @@ case "${LINUX_VER}" in
     add-apt-repository ppa:git-core/ppa -y
     apt-get update
     apt-get upgrade -y
+
+    # tzdata is needed by the ORC library used by pyarrow, because it provides /etc/localtime
+    # On Ubuntu 24.04 and newer, we also need tzdata-legacy
+    os_version=$(grep 'VERSION_ID' /etc/os-release | cut -d '"' -f 2)
+    if [[ "${os_version}" > "24.04" ]] || [[ "${os_version}" == "24.04" ]]; }; then
+        tzdata_pkgs="tzdata tzdata-legacy"
+    else
+        tzdata_pkgs="tzdata"
+    fi
+
     apt-get install -y --no-install-recommends \
       wget curl git jq ssh \
       make build-essential libssl-dev zlib1g-dev \
       libbz2-dev libreadline-dev libsqlite3-dev wget \
       curl llvm libncursesw5-dev xz-utils tk-dev unzip \
-      libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+      libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
+      ${tzdata_pkgs}
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
     ;;
   "rockylinux"*)

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -40,9 +40,9 @@ case "${LINUX_VER}" in
     # On Ubuntu 24.04 and newer, we also need tzdata-legacy
     os_version=$(grep 'VERSION_ID' /etc/os-release | cut -d '"' -f 2)
     if [[ "${os_version}" > "24.04" ]] || [[ "${os_version}" == "24.04" ]]; then
-        tzdata_pkgs="tzdata tzdata-legacy"
+        tzdata_pkgs=(tzdata tzdata-legacy)
     else
-        tzdata_pkgs="tzdata"
+        tzdata_pkgs=(tzdata)
     fi
 
     apt-get install -y --no-install-recommends \
@@ -51,7 +51,7 @@ case "${LINUX_VER}" in
       libbz2-dev libreadline-dev libsqlite3-dev wget \
       curl llvm libncursesw5-dev xz-utils tk-dev unzip \
       libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
-      ${tzdata_pkgs}
+      "${tzdata_pkgs[@]}"
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
     ;;
   "rockylinux"*)


### PR DESCRIPTION
We need `tzdata-legacy` on Ubuntu 24.04 to supply legacy timezones like `US/Pacific` that are used by test data files.

More info:
- https://github.com/rapidsai/cudf/pull/16998#issuecomment-2400980607
- https://github.com/apache/orc/issues/2049
