### PR TITLE
add pydistcheck to ci-wheel image

### DIFF
--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -137,6 +137,7 @@ python -m pip install \
   conda-package-handling \
   dunamai \
   patchelf \
+  'pydistcheck==0.8.*' \
   "rapids-dependency-file-generator==1.*" \
   twine
 pyenv rehash

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -138,7 +138,7 @@ python -m pip install \
   dunamai \
   patchelf \
   'pydistcheck==0.8.*' \
-  "rapids-dependency-file-generator==1.*" \
+  'rapids-dependency-file-generator==1.*' \
   twine
 pyenv rehash
 EOF


### PR DESCRIPTION
contributes to https://github.com/rapidsai/build-planning/issues/110

Adds `pydistcheck` to the `ci-wheel` image, used for wheel-building in RAPIDS CI.

## Notes for Reviewers

Example of how it'll be used: https://github.com/rapidsai/cudf/pull/17284