### PR TITLE
re-enable CUDA 12.0.1 ci-wheel images

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -42,8 +42,6 @@ exclude:
   # Only build ci-wheel for the latest CUDA of each major version
   - CUDA_VER: "11.4.3"
     IMAGE_REPO: "ci-wheel"
-  - CUDA_VER: "12.0.1"
-    IMAGE_REPO: "ci-wheel"
   - CUDA_VER: "12.2.2"
     IMAGE_REPO: "ci-wheel"
 


### PR DESCRIPTION
`pynvjitlink` relies on CUDA 12.0.1 `ci-wheel` images, but we stopped producing new ones as of #194.

This proposes re-introducing them, for the reasons mentioned in https://github.com/rapidsai/pynvjitlink/pull/114#discussion_r1841375612