### PR TITLE
add 'wheel' to ci-wheel image

### DIFF
--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -139,7 +139,8 @@ python -m pip install \
   patchelf \
   'pydistcheck==0.8.*' \
   'rapids-dependency-file-generator==1.*' \
-  twine
+  twine \
+  wheel
 pyenv rehash
 EOF
 


### PR DESCRIPTION
Closes #138

Proposes installing `wheel` in the `ci-wheel` images, to remove the need to install it at build time on every CI run for header-only C++ wheel builds, like `librmm` does:

```shell
python -m pip install wheel
python -m wheel tags --platform any dist/* --remove
```

([rmm/ci/build_wheel.sh](https://github.com/rapidsai/rmm/blob/d4066fa611c803430c9bc5dbe8e243f89bb9a25c/ci/build_wheel_cpp.sh#L23-L24))