### PR TITLE
Enable 'quiet: true' in condarc

### DIFF
--- a/context/condarc.tmpl
+++ b/context/condarc.tmpl
@@ -13,3 +13,4 @@ conda-build:
   output_folder: $RAPIDS_CONDA_BLD_OUTPUT_DIR
 number_channel_notices: 0
 always_yes: true
+quiet: true


### PR DESCRIPTION
See https://github.com/rapidsai/build-planning/issues/126.

We are getting lots and lots of noisy log lines with no content, because progress bars are being included in our CI log lines. This sets `quiet: true` for conda to help with the problem.
