### PR TITLE
Revert "Enable 'quiet: true' in condarc"

### DIFF
--- a/context/condarc.tmpl
+++ b/context/condarc.tmpl
@@ -13,4 +13,3 @@ conda-build:
   output_folder: $RAPIDS_CONDA_BLD_OUTPUT_DIR
 number_channel_notices: 0
 always_yes: true
-quiet: true

--- a/context/condarc.tmpl
+++ b/context/condarc.tmpl
@@ -13,3 +13,12 @@ conda-build:
   output_folder: $RAPIDS_CONDA_BLD_OUTPUT_DIR
 number_channel_notices: 0
 always_yes: true
+
+# threads to use when downloading and reading repodata
+repodata_threads: 1
+
+# threads to use when downloading packages
+fetch_threads: 1
+
+# default for all other multi-threaded operations
+default_threads: 1


### PR DESCRIPTION
Reverts rapidsai/ci-imgs#217.

It seems like we have lost some useful information from conda, and Python exception names are no longer being printed. This makes rapids-conda-retry ineffective. @pentschev and I suspect the change to quiet mode may be the root cause. We would like to try reverting it to see if this changes.

We may also need to do something to make conda stop printing all the extra newlines in progress bars that led to #217 in the first place…