### PR TITLE
Update dependencies

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -9,4 +9,4 @@ CODECOV_VER: 9.0.4
 # renovate: datasource=docker depName=mikefarah/yq versioning=docker
 YQ_VER: 4.44.5
 # renovate: datasource=docker depName=amazon/aws-cli versioning=docker
-AWS_CLI_VER: 2.22.8
+AWS_CLI_VER: 2.22.28


### PR DESCRIPTION
Combines changes from several PRs, to reduce CI churn. Closes #221, closes #222, closes #223, closes #224.
- Update mikefarah/yq Docker tag to v4.44.6
- Update dependency cli/cli to v2.64.0
- Update dependency codecov-cli to v9.1.1
- Update amazon/aws-cli Docker tag to v2.22.28
