### PR TITLE
Remove pytorch channel.

### DIFF
--- a/context/condarc.tmpl
+++ b/context/condarc.tmpl
@@ -3,7 +3,6 @@ channels:
   - rapidsai
   - rapidsai-nightly
   - dask/label/dev
-  - pytorch
   - conda-forge
   - nvidia
 conda-build:


### PR DESCRIPTION
Closes https://github.com/rapidsai/ci-imgs/issues/227.
