### PR TITLE
ci-wheel: always use auditwheel packages with wildcard support

### DIFF
--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -186,7 +186,7 @@ RUN <<EOF
 pyenv global ${PYTHON_VER}
 python -m pip install --upgrade pip
 python -m pip install \
-  auditwheel \
+  'auditwheel>=6.2.0' \
   certifi \
   conda-package-handling \
   dunamai \


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/137

Starting with the work for that issue, we began relying on support for wildcards in `auditwheel repair --exclude` in wheel builds:

* https://github.com/rapidsai/cugraph/pull/4877
* https://github.com/rapidsai/raft/pull/2548

That feature was first added to `auditwheel` (by our own @KyleFromNVIDIA !) in release 6.2.0:

* https://github.com/pypa/auditwheel/pull/508
* https://github.com/pypa/auditwheel/releases/tag/6.2.0

This proposes putting a floor of `>=6.2.0` on `auditwheel`, to be sure images here always get a sufficiently new version to support that.

## Notes for Reviewers

All seems to be going fine in CI... this PR is inspired by me seeing the use of wildcards fail locally using a slightly older `rapidsai/ci-wheel` image that had a slightly older `auditwheel` in it.

I think we'll be happy to have this protection... if some other dependency conflict resulted in `auditwheel` silently being downgraded here, it could be tough to track backwards from the failures in wheel-building CI to that being the cause.