### PR TITLE
increase pip retries from 5 to 10

### DIFF
--- a/context/pip.conf
+++ b/context/pip.conf
@@ -4,3 +4,10 @@ quiet = 0
 extra-index-url =
     https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
     https://pypi.nvidia.com
+
+# Maximum number of times to retry failed connection requests.
+# Higher values reduce the incidence of errors like this:
+#
+#   "Failed to establish a new connection: [Errno -3] Temporary failure in name resolution"
+#
+retries = 10


### PR DESCRIPTION
We occasionally see failures from `pip install` like this:

```text
WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7654e7c07610>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution')': /packages/e4/40/3c4d9862bebcd3c7d54c06e3bdff0a2ab503d2df98d8c15b337c7b864f0a/uv-0.1.45-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
2100.5 ERROR: Could not install packages due to an OSError: HTTPSConnectionPool(host='files.pythonhosted.org', port=443): Max retries exceeded with url: /packages/e4/40/3c4d9862bebcd3c7d54c06e3bdff0a2ab503d2df98d8c15b337c7b864f0a/uv-0.1.45-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (Caused by NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7654e7c077c0>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution'))
```

By default, `pip` will retry such failures 5 times before considering the attempt failed and exiting with a non-0 exit code (https://pip.pypa.io/en/stable/cli/pip/#cmdoption-retries).

This PR proposes:

* explicitly configuring a value for that setting
* doubling the allowed retries, from 5 (the default) to 10

I think this configuration narrowly refers to failed **connections** with remote package repositories, and wouldn't result in `pip` retrying failures like those that led to https://github.com/rapidsai/gha-tools/pull/132.

But more retries would still reduce the incidence of failed CI runs.