### PR TITLE
Install `rattler-build` in Conda CI images

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -221,7 +221,9 @@ rapids-mamba-retry install -y \
   jq \
   packaging \
   "python>=${PYTHON_VERSION},<${PYTHON_VER_UPPER_BOUND}=*_cpython" \
-  "rapids-dependency-file-generator==1.*"
+  "rapids-dependency-file-generator==1.*" \
+  rattler-build \
+;
 conda clean -aipty
 EOF
 


### PR DESCRIPTION
Part of issue: https://github.com/rapidsai/build-planning/issues/47

Adds `rattler-build` to our CI images so that we can start using in RAPIDS Conda package builds.