### PR TITLE
Add timeout to image builds.

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -31,6 +31,7 @@ on:
 jobs:
   run:
     name: build (${{ matrix.CUDA_VER }}, ${{ matrix.PYTHON_VER }}, ${{ matrix.LINUX_VER }}, ${{ matrix.ARCH }})
+    timeout-minutes: 30
     strategy:
       max-parallel: 50
       matrix:


### PR DESCRIPTION
Recently some image builds failed but did not exit for unclear reasons. This resulted in the jobs consuming the full 6 hour time allowed by GitHub Actions.

Examples:
- https://github.com/rapidsai/ci-imgs/actions/runs/13044383798/job/36392385934
- https://github.com/rapidsai/ci-imgs/actions/runs/13044383798/job/36392394499
- https://github.com/rapidsai/ci-imgs/actions/runs/13044383798/job/36392385934

Most jobs take less than 10 minutes, so this PR sets a timeout of 30 minutes to prevent resources from being wasted.
