### PR TITLE
Use CUDA 12.8.0 in latest tag

### DIFF
--- a/latest.yaml
+++ b/latest.yaml
@@ -1,18 +1,18 @@
 # Define the values used for the "latest" tag
 miniforge-cuda:
-  CUDA_VER: "12.5.1"
+  CUDA_VER: "12.8.0"
   PYTHON_VER: "3.12"
   LINUX_VER: "ubuntu24.04"
 ci-conda:
-  CUDA_VER: "12.5.1"
+  CUDA_VER: "12.8.0"
   PYTHON_VER: "3.12"
   LINUX_VER: "ubuntu24.04"
 ci-wheel:
-  CUDA_VER: "12.5.1"
+  CUDA_VER: "12.8.0"
   PYTHON_VER: "3.12"
   # Wheels should always be built with the oldest supported glibc version
   LINUX_VER: "rockylinux8"
 citestwheel:
-  CUDA_VER: "12.5.1"
+  CUDA_VER: "12.8.0"
   PYTHON_VER: "3.12"
   LINUX_VER: "ubuntu24.04"


### PR DESCRIPTION
This updates the `latest` tag of each image to use CUDA 12.8.0.

xref: https://github.com/rapidsai/build-planning/issues/139