### PR TITLE
Add `conda-verify` to CI images

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -215,7 +215,9 @@ rapids-mamba-retry install -y \
   boa \
   ca-certificates \
   certifi \
+  conda-build \
   conda-package-handling \
+  conda-verify \
   dunamai \
   git \
   jq \


### PR DESCRIPTION
This adds `conda-verify` to our CI images to resolve a warning about it being missing.