### PR TITLE
Explicitly require `conda-build`

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -215,6 +215,7 @@ rapids-mamba-retry install -y \
   boa \
   ca-certificates \
   certifi \
+  conda-build \
   conda-package-handling \
   dunamai \
   git \


### PR DESCRIPTION
Currently `conda-build` is pulled in indirectly via `boa`. However we do depend on `conda-build` as well. So this makes it an explicit dependency. This shouldn't otherwise change current behavior.