### PR TITLE
Stop building ci-wheel for CUDA 12.5.1.

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -47,6 +47,8 @@ exclude:
     IMAGE_REPO: "ci-wheel"
   - CUDA_VER: "12.2.2"
     IMAGE_REPO: "ci-wheel"
+  - CUDA_VER: "12.5.1"
+    IMAGE_REPO: "ci-wheel"
 
   # Only build ci-wheel for the oldest glibc (rockylinux8)
   - LINUX_VER: "ubuntu20.04"


### PR DESCRIPTION
We are currently building and publishing `ci-wheel` images for CUDA 12.5.1. We now use CUDA 12.8.0 for all builds, and can remove that.
