### PR TITLE
Readd `boa` for RAPIDS 25.02

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -214,6 +214,7 @@ RUN cat /tmp/condarc.tmpl | envsubst | tee /opt/conda/.condarc; \
 RUN <<EOF
 rapids-mamba-retry install -y \
   anaconda-client \
+  boa \
   ca-certificates \
   certifi \
   conda-build \


### PR DESCRIPTION
Reverts https://github.com/rapidsai/ci-imgs/pull/238

As RAPIDS 25.02 work is still happening and appears to still need boa in some cases, readd it to our CI images to get RAPIDS 25.02 through.

We can retry dropping `boa` after the RAPIDS 25.02 is complete.