### PR TITLE
Drop boa from Conda images (pt. 2)

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -214,7 +214,6 @@ RUN cat /tmp/condarc.tmpl | envsubst | tee /opt/conda/.condarc; \
 RUN <<EOF
 rapids-mamba-retry install -y \
   anaconda-client \
-  boa \
   ca-certificates \
   certifi \
   conda-build \


### PR DESCRIPTION
Closes https://github.com/rapidsai/build-planning/issues/149

Upstream has archived `boa` and recommended moving to `rattler-build`. So this drops `boa` from our images.

Also as `boa` does not support Python 3.13 (unmaintained), dropping `boa` is a prerequisite to adding Python 3.13. There are other dependencies it pins to old versions that will be able to get updates too.

We tried dropping this before, but it caused issues with the RAPIDS 25.02 release. Once the RAPIDS 25.02 release is complete, let's give this another try.