### PR TITLE
updates: codecov-cli (10.2.0), gh CLI (2.67.0), AWS CLI (2.24.16), yq (4.45.1)

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -5,7 +5,7 @@ SCCACHE_VER: 0.7.7
 # renovate: datasource=github-releases depName=cli/cli
 GH_CLI_VER: 2.67.0
 # renovate: datasource=pypi depName=codecov-cli
-CODECOV_VER: 9.1.1
+CODECOV_VER: 10.2.0
 # renovate: datasource=docker depName=mikefarah/yq versioning=docker
 YQ_VER: 4.45.1
 # renovate: datasource=docker depName=amazon/aws-cli versioning=docker

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,12 +3,12 @@
 # prefer sticking with a stable version until a specific reason to update arises.
 SCCACHE_VER: 0.7.7
 # renovate: datasource=github-releases depName=cli/cli
-GH_CLI_VER: 2.64.0
+GH_CLI_VER: 2.67.0
 # renovate: datasource=pypi depName=codecov-cli
 CODECOV_VER: 9.1.1
 # renovate: datasource=docker depName=mikefarah/yq versioning=docker
-YQ_VER: 4.44.6
+YQ_VER: 4.45.1
 # renovate: datasource=docker depName=amazon/aws-cli versioning=docker
-AWS_CLI_VER: 2.22.28
+AWS_CLI_VER: 2.24.16
 # renovate: datasource=docker depName=condaforge/miniforge3 versioning=docker
 MINIFORGE_VER: 24.11.3-0


### PR DESCRIPTION
Closes #250
Closes #252
Closes #253

Consolidates all the other automatic updates for dependencies here.