### PR TITLE
Force remove package cache and remove rust from CI images

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -234,7 +234,6 @@ else
     PYTHON_ABI_TAG="cpython"
 fi
 
-# rust is needed for source builds of codecov-cli -- binaries are not available for Python 3.13 yet.
 rapids-mamba-retry install -y \
   anaconda-client \
   ca-certificates \
@@ -248,7 +247,6 @@ rapids-mamba-retry install -y \
   "python>=${PYTHON_VERSION},<${PYTHON_UPPER_BOUND}=*_${PYTHON_ABI_TAG}" \
   "rapids-dependency-file-generator==1.*" \
   rattler-build \
-  rust \
 ;
 conda clean -aiptfy
 EOF
@@ -275,9 +273,14 @@ EOF
 # Install codecov from source distribution
 ARG CODECOV_VER=notset
 RUN <<EOF
+# rust is needed for source builds of codecov-cli -- binaries are not available for Python 3.13 yet.
+# We must also remove rust in this step because it ships 750MB of documentation files.
+rapids-mamba-retry install -y rust
 # temporary workaround for discovered codecov binary install issue. See rapidsai/ci-imgs/issues/142
 pip install codecov-cli==${CODECOV_VER}
 pip cache purge
+rapids-mamba-retry uninstall rust
+conda clean -aiptfy
 EOF
 
 RUN /opt/conda/bin/git config --system --add safe.directory '*'

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -54,7 +54,7 @@ fi
 find /opt/conda -follow -type f -name '*.a' -delete
 find /opt/conda -follow -type f -name '*.pyc' -delete
 # recreate missing libstdc++ symlinks
-conda clean -afy
+conda clean -aiptfy
 EOF
 
 # Reassign root's primary group to root

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -279,7 +279,7 @@ rapids-mamba-retry install -y rust
 # temporary workaround for discovered codecov binary install issue. See rapidsai/ci-imgs/issues/142
 pip install codecov-cli==${CODECOV_VER}
 pip cache purge
-rapids-mamba-retry uninstall rust
+rapids-mamba-retry uninstall -n base -y rust
 conda clean -aiptfy
 EOF
 

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -204,7 +204,7 @@ esac
 EOF
 
 # Install gha-tools
-RUN wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - \
+RUN wget -q https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - \
   | tar -xz -C /usr/local/bin
 
 # Install prereq for envsubst
@@ -264,7 +264,7 @@ mv "/tmp/sccache-v${SCCACHE_VER}-"${REAL_ARCH}"-unknown-linux-musl/sccache" /usr
 chmod +x /usr/bin/sccache
 rm -rf /tmp/sccache.tar.gz "/tmp/sccache-v${SCCACHE_VER}-"${REAL_ARCH}"-unknown-linux-musl"
 
-wget https://github.com/cli/cli/releases/download/v${GH_CLI_VER}/gh_${GH_CLI_VER}_linux_${CPU_ARCH}.tar.gz
+wget -q https://github.com/cli/cli/releases/download/v${GH_CLI_VER}/gh_${GH_CLI_VER}_linux_${CPU_ARCH}.tar.gz
 tar -xf gh_*.tar.gz
 mv gh_*/bin/gh /usr/local/bin
 rm -rf gh_*

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -211,7 +211,7 @@ RUN wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.ta
 RUN <<EOF
 rapids-mamba-retry install -y \
   gettext
-conda clean -aipty
+conda clean -aiptfy
 EOF
 
 # Create condarc file from env vars
@@ -250,7 +250,7 @@ rapids-mamba-retry install -y \
   rattler-build \
   rust \
 ;
-conda clean -aipty
+conda clean -aiptfy
 EOF
 
 # Install sccache and gh cli

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -123,7 +123,7 @@ case "${LINUX_VER}" in
       source /opt/rh/gcc-toolset-11/enable \
     ' > /etc/profile.d/enable_devtools.sh
     pushd tmp
-    wget https://www.openssl.org/source/openssl-1.1.1k.tar.gz
+    wget -q https://www.openssl.org/source/openssl-1.1.1k.tar.gz
         tar -xzvf openssl-1.1.1k.tar.gz
     cd openssl-1.1.1k
     ./config --prefix=/usr --openssldir=/etc/ssl --libdir=lib no-shared zlib-dynamic
@@ -142,7 +142,7 @@ EOF
 ARG GH_CLI_VER=notset
 RUN <<EOF
 set -e
-wget https://github.com/cli/cli/releases/download/v${GH_CLI_VER}/gh_${GH_CLI_VER}_linux_${CPU_ARCH}.tar.gz
+wget -q https://github.com/cli/cli/releases/download/v${GH_CLI_VER}/gh_${GH_CLI_VER}_linux_${CPU_ARCH}.tar.gz
 tar -xf gh_*.tar.gz
 mv gh_*/bin/gh /usr/local/bin
 rm -rf gh_*
@@ -202,7 +202,7 @@ pyenv rehash
 EOF
 
 # Install latest gha-tools
-RUN wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
+RUN wget -q https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
 
 # Install anaconda-client
 RUN <<EOF

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -153,7 +153,7 @@ pyenv rehash
 EOF
 
 # Install latest gha-tools
-RUN -q wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - \
+RUN wget -q https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - \
   | tar -xz -C /usr/local/bin
 
 # git safe directory

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -101,7 +101,7 @@ case "${LINUX_VER}" in
     update-ca-trust extract
     dnf clean all
     pushd tmp
-    wget https://www.openssl.org/source/openssl-1.1.1k.tar.gz
+    wget -q https://www.openssl.org/source/openssl-1.1.1k.tar.gz
         tar -xzvf openssl-1.1.1k.tar.gz
     cd openssl-1.1.1k
     ./config --prefix=/usr --openssldir=/etc/ssl --libdir=lib no-shared zlib-dynamic
@@ -120,7 +120,7 @@ EOF
 ARG GH_CLI_VER=notset
 RUN <<EOF
 set -e
-wget https://github.com/cli/cli/releases/download/v${GH_CLI_VER}/gh_${GH_CLI_VER}_linux_${CPU_ARCH}.tar.gz
+wget -q https://github.com/cli/cli/releases/download/v${GH_CLI_VER}/gh_${GH_CLI_VER}_linux_${CPU_ARCH}.tar.gz
 tar -xf gh_*.tar.gz
 mv gh_*/bin/gh /usr/local/bin
 rm -rf gh_*
@@ -153,7 +153,7 @@ pyenv rehash
 EOF
 
 # Install latest gha-tools
-RUN wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - \
+RUN -q wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - \
   | tar -xz -C /usr/local/bin
 
 # git safe directory


### PR DESCRIPTION
This PR improves ci-conda image sizes.

### Purge the package cache

Currently we are shipping a large package cache in `/opt/conda/pkgs` that is not needed.
```
$ docker run -it rapidsai/ci-conda:latest bash -c 'du -sh /opt/conda/*'
...
1.1G    /opt/conda/pkgs
```

The guidance from `conda clean --help` says:
```
-p, --packages        Remove unused packages from writable package caches. WARNING: This does not check for packages installed using symlinks back to the package cache.
...
-f, --force-pkgs-dirs
                      Remove *all* writable package caches. This option is not included with the --all flag. WARNING: This will break environments with packages installed using symlinks back to the package cache.
```

We don't install any packages with symlinks back to the package cache. I verified that removing the `/opt/conda/pkgs` directory does not break any symlinks.

```
# conda clean -f
# cd /opt/conda && find . -xtype l
./x86_64-conda-linux-gnu/lib/libgfortran.so.5
./x86_64-conda-linux-gnu/lib/libgfortran.so.5.0.0
./x86_64-conda-linux-gnu/lib/libgfortran.so
./lib/gcc/x86_64-conda-linux-gnu/14.2.0/libhwasan.so
```

Those unresolved symlinks are expected (unchanged from before cleaning).

Guidance that this is safe:
- https://stackoverflow.com/questions/56266229/is-it-safe-to-manually-delete-all-files-in-pkgs-folder-in-anaconda-python
- https://web.archive.org/web/20240404213219/https://groups.google.com/a/anaconda.com/g/anaconda/c/xV1BiGPmgao

### Don't include rust

I added `rust` in #207 so that we could build `codecov-cli` from source for Python 3.13. This greatly increased our image size because `rust` ships a TON of documentation, including 750 MB of HTML.

```
/opt/conda/share/doc/rust# du -sh *
...
691M    html
56M     json
```

There are also a few other dependencies that we can eliminate by uninstalling rust. Here is the before/after of uninstalling `rust`:

```
/opt/conda# du -sh .
2.6G    .
/opt/conda# mamba uninstall rust
...
/opt/conda# du -sh .
639M    .
```