### PR TITLE
stop running 'pyenv update' in builds

### DIFF
--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -165,10 +165,6 @@ ENV AUDITWHEEL_POLICY=${POLICY} AUDITWHEEL_ARCH=${REAL_ARCH} AUDITWHEEL_PLAT=${P
 # Install pyenv
 RUN curl https://pyenv.run | bash
 
-# Create pyenvs
-# TODO: Determine if any cleanup of the pyenv layers is needed to shrink the container
-RUN pyenv update
-
 RUN <<EOF
 case "${LINUX_VER}" in
   "ubuntu"*)

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -130,9 +130,11 @@ EOF
 RUN curl https://pyenv.run | bash
 
 # Create pyenvs
-RUN pyenv update && pyenv install ${PYTHON_VER}
-
-RUN pyenv global ${PYTHON_VER} && python --version
+RUN <<EOF
+  pyenv install ${PYTHON_VER}
+  pyenv global ${PYTHON_VER}
+  python --version
+EOF
 
 # add bin to path
 ENV PATH="/pyenv/versions/${PYTHON_VER}/bin/:$PATH"


### PR DESCRIPTION
Fixes #257 (hopefully)

Attempts to avoid the problems documented there by just not running `pyenv update` in builds. `pyenv update` shouldn't be necessary for these builds... we're creating new environments from scratch, and not trying to pin to specific versions of `pyenv`.