### PR TITLE
Pin libxml2<2.14.0 temporarily

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -31,6 +31,10 @@ RUN chmod g+ws /opt/conda
 RUN <<EOF
 # Ensure new files/dirs have group write permissions
 umask 002
+
+# Temporary workaround for unstable libxml2 packages
+echo 'libxml2<2.14.0' >> /opt/conda/conda-meta/pinned
+
 # update everything before other environment changes, to ensure mixing
 # an older conda with newer packages still works well
 conda update --all -y -n base

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -33,6 +33,7 @@ RUN <<EOF
 umask 002
 
 # Temporary workaround for unstable libxml2 packages
+# xref: https://github.com/conda-forge/libxml2-feedstock/issues/145
 echo 'libxml2<2.14.0' >> /opt/conda/conda-meta/pinned
 
 # update everything before other environment changes, to ensure mixing


### PR DESCRIPTION
This is a temporary workaround to prevent upgrading `libxml2` to `2.14.0` which has ABI changes.

Ref:
- https://github.com/conda-forge/libxml2-feedstock/issues/145
- https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/999
- https://github.com/mamba-org/mamba/issues/3883