### PR TITLE
Drop CUDA 12.5.1 images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ The `latest` image tags are controlled by the values in `latest.yaml`.
 To build the dockerfiles locally, you may use the following snippets:
 
 ```sh
-export LINUX_VER=ubuntu22.04
-export CUDA_VER=12.5.1
+export LINUX_VER=ubuntu24.04
+export CUDA_VER=12.8.0
 export PYTHON_VER=3.12
 export ARCH=amd64
 export IMAGE_REPO=ci-conda

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -3,7 +3,6 @@ CUDA_VER:
   - "11.8.0"
   - "12.0.1"
   - "12.2.2"
-  - "12.5.1"
   - "12.8.0"
 PYTHON_VER:
   - "3.10"
@@ -47,8 +46,6 @@ exclude:
   - CUDA_VER: "12.0.1"
     IMAGE_REPO: "ci-wheel"
   - CUDA_VER: "12.2.2"
-    IMAGE_REPO: "ci-wheel"
-  - CUDA_VER: "12.5.1"
     IMAGE_REPO: "ci-wheel"
 
   # Only build ci-wheel for the oldest glibc (rockylinux8)


### PR DESCRIPTION
Resolves https://github.com/rapidsai/ci-imgs/issues/232.
