### PR TITLE
Group low-risk CLI tools in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
-  "schedule": ["before 7am on the first day of the month"],
-  "regexManagers": [
+  "extends": [
+    "config:recommended"
+  ],
+  "schedule": [
+    "before 7am on the first day of the month"
+  ],
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": "versions.yaml",
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[^ ]+) depName=(?<depName>[^\\s]+)(?:\\s+versioning=(?<versioning>[^\\n]+))?\\n(?<depNameCapture>[^:]+): (?<currentValue>[^\\n]+)"

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,15 @@
   "schedule": [
     "before 7am on the first day of the month"
   ],
+  "packageRules": [
+    {
+      "description": "Update low-risk CLI tools together",
+      "matchPackagePatterns": [
+        "^(amazon/aws-cli|cli/cli|codecov-cli|mikefarah/yq)$"
+      ],
+      "groupName": "cli-tools"
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
This PR groups low-risk CLI tools (amazon/aws-cli, cli/cli, codecov-cli, mikefarah/yq) together in the Renovate configuration to reduce noise and CI resource usage. This follows the pattern suggested in #226 and the Renovate documentation for package grouping.