### PR TITLE
Update to `pydistcheck` version `0.9`

### DIFF
--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -190,7 +190,7 @@ python -m pip install \
   conda-package-handling \
   dunamai \
   patchelf \
-  'pydistcheck==0.8.*' \
+  'pydistcheck==0.9.*' \
   'rapids-dependency-file-generator==1.*' \
   twine \
   wheel


### PR DESCRIPTION
When `pydistcheck` was added in PR ( https://github.com/rapidsai/ci-imgs/pull/205 ), it was added pinned to `0.8`, which at the time was the latest version `pydistcheck`. IOW it was pinned as a safety measure to make sure updating was done intentionally.

Since then `pydistcheck` released [`0.9.0`]( https://github.com/jameslamb/pydistcheck/releases/tag/v0.9.0 ) & [`0.9.1`]( https://github.com/jameslamb/pydistcheck/releases/tag/v0.9.1 ). The last release was in March of this year. So it seems pretty stable.

Also the new releases include an important feature. Namely the ability to increase precision in the file size checks. As we spend more time scruntinizing wheel size increases, being able to increase precision will help us to differentiate between a significant increase and a modest cross-over of a rounding threshold. For example `1.44GB` to `1.45GB` at the default 2 digit precision appears as `1.4GB` to `1.5GB`, which is very different from `1.41GB` to `1.49GB`.

To enable use of the new `pydistcheck` release, this bumps the pin to `0.9`.