### PR TITLE
Revert "refactor: remove cuda11 channels and enable strict channel priority"

### DIFF
--- a/context/condarc.tmpl
+++ b/context/condarc.tmpl
@@ -2,7 +2,9 @@ auto_update_conda: False
 channels:
   - rapidsai
   - rapidsai-nightly
+  - dask/label/dev
   - conda-forge
+  - nvidia
 conda-build:
   pkg_format: '2'
   set_build_id: false
@@ -10,7 +12,6 @@ conda-build:
   output_folder: $RAPIDS_CONDA_BLD_OUTPUT_DIR
 number_channel_notices: 0
 always_yes: true
-channel_priority: strict
 
 # threads to use when downloading and reading repodata
 repodata_threads: 1


### PR DESCRIPTION
Reverts rapidsai/ci-imgs#273 until after the 25.06 release. 