### PR TITLE
Downgrade cuda-compat-12-8 due to upstream bug

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -94,7 +94,7 @@ case "${LINUX_VER}" in
 
     # Downgrade cuda-compat on CUDA 12.8 due to an upstream bug
     if [[ "${CUDA_VER}" == "12.8"* ]]; then
-      apt-get install -y cuda-compat-12-8=570.148.08-0ubuntu1
+      apt-get install -y --allow-downgrades cuda-compat-12-8=570.148.08-0ubuntu1
     fi
 
     rm -rf "/var/lib/apt/lists/*"

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -10,6 +10,7 @@ ARG MINIFORGE_VER=notset
 FROM condaforge/miniforge3:${MINIFORGE_VER} AS miniforge-upstream
 FROM nvidia/cuda:${CUDA_VER}-base-${LINUX_VER} AS miniforge-cuda
 
+ARG CUDA_VER
 ARG LINUX_VER
 ARG PYTHON_VER
 ARG DEBIAN_FRONTEND=noninteractive

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -90,6 +90,12 @@ case "${LINUX_VER}" in
     apt-get upgrade -y
     apt-get install -y --no-install-recommends \
       "${tzdata_pkgs[@]}"
+
+    # Downgrade cuda-compat on CUDA 12.8 due to an upstream bug
+    if [[ "${CUDA_VER}" == "12.8"* ]]; then
+      apt-get install -y cuda-compat-12-8=570.148.08-0ubuntu1
+    fi
+
     rm -rf "/var/lib/apt/lists/*"
     ;;
   "rockylinux"*)

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -78,7 +78,7 @@ case "${LINUX_VER}" in
     update-ca-certificates
 
     # Downgrade cuda-compat on CUDA 12.8 due to an upstream bug
-    if [[ "${RAPIDS_CUDA_VERSION}" == "12.8"* ]]; then
+    if [[ "${CUDA_VER}" == "12.8"* ]]; then
       apt-get install -y cuda-compat-12-8=570.148.08-0ubuntu1
     fi
 

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -79,7 +79,7 @@ case "${LINUX_VER}" in
 
     # Downgrade cuda-compat on CUDA 12.8 due to an upstream bug
     if [[ "${CUDA_VER}" == "12.8"* ]]; then
-      apt-get install -y cuda-compat-12-8=570.148.08-0ubuntu1
+      apt-get install -y --allow-downgrades cuda-compat-12-8=570.148.08-0ubuntu1
     fi
 
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -76,6 +76,12 @@ case "${LINUX_VER}" in
       xz-utils \
       zlib1g-dev
     update-ca-certificates
+
+    # Downgrade cuda-compat on CUDA 12.8 due to an upstream bug
+    if [[ "${RAPIDS_CUDA_VERSION}" == "12.8"* ]]; then
+      apt-get install -y cuda-compat-12-8=570.148.08-0ubuntu1
+    fi
+
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
     ;;
   "rockylinux"*)


### PR DESCRIPTION
@gmarkall reported an issue with `cuda-compat-12-8`. This can be worked around temporarily by installing `cuda-compat-12-8=570.148.08-0ubuntu1`.

cc: @jakirkham @kkraus14