### PR TITLE
Use zstd compression for images

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -78,4 +78,4 @@ jobs:
           target: ${{ inputs.DOCKER_TARGET }}
           tags: ${{ inputs.IMAGE_NAME }}-${{ matrix.ARCH }}
           # Enable zstd compression (gzip is default)
-          outputs: type=registry,compression=zstd,force-compression=true,oci-mediatypes=true,compression-level=20
+          outputs: type=registry,compression=zstd,force-compression=true,oci-mediatypes=true,compression-level=18

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -78,3 +78,5 @@ jobs:
             ${{ steps.generate-build-args.outputs.ARGS }}
           target: ${{ inputs.DOCKER_TARGET }}
           tags: ${{ inputs.IMAGE_NAME }}-${{ matrix.ARCH }}
+          # Enable zstd compression (gzip is default)
+          outputs: type=image,compression=zstd

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -32,7 +32,7 @@ on:
 jobs:
   run:
     name: build (${{ matrix.CUDA_VER }}, ${{ matrix.PYTHON_VER }}, ${{ matrix.LINUX_VER }}, ${{ matrix.ARCH }})
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       max-parallel: 50
       matrix:

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -81,3 +81,7 @@ jobs:
           # Compression level 15 is rough based on empirical testing
           # https://github.com/rapidsai/ci-imgs/pull/281#issuecomment-3001509856
           outputs: type=registry,compression=zstd,force-compression=true,oci-mediatypes=true,compression-level=15
+          # Disable provenance and SBOM generation
+          # https://github.com/docker/build-push-action/issues/755
+          provenance: false
+          sbom: false

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver: docker
+          driver: docker-container
           endpoint: builders
       - name: Generate Build Args
         id: generate-build-args

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -72,11 +72,10 @@ jobs:
         with:
           context: context
           file: ${{ inputs.DOCKERFILE }}
-          push: true
           pull: true
           build-args: |
             ${{ steps.generate-build-args.outputs.ARGS }}
           target: ${{ inputs.DOCKER_TARGET }}
           tags: ${{ inputs.IMAGE_NAME }}-${{ matrix.ARCH }}
           # Enable zstd compression (gzip is default)
-          outputs: type=image,compression=zstd,force-compression=true,oci-mediatypes=true
+          outputs: type=registry,compression=zstd,force-compression=true,oci-mediatypes=true

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -78,4 +78,6 @@ jobs:
           target: ${{ inputs.DOCKER_TARGET }}
           tags: ${{ inputs.IMAGE_NAME }}-${{ matrix.ARCH }}
           # Enable zstd compression (gzip is default)
-          outputs: type=registry,compression=zstd,force-compression=true,oci-mediatypes=true,compression-level=18
+          # Compression level 15 is rough based on empirical testing
+          # https://github.com/rapidsai/ci-imgs/pull/281#issuecomment-3001509856
+          outputs: type=registry,compression=zstd,force-compression=true,oci-mediatypes=true,compression-level=15

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -78,4 +78,4 @@ jobs:
           target: ${{ inputs.DOCKER_TARGET }}
           tags: ${{ inputs.IMAGE_NAME }}-${{ matrix.ARCH }}
           # Enable zstd compression (gzip is default)
-          outputs: type=registry,compression=zstd,force-compression=true,oci-mediatypes=true
+          outputs: type=registry,compression=zstd,force-compression=true,oci-mediatypes=true,compression-level=20

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -79,4 +79,4 @@ jobs:
           target: ${{ inputs.DOCKER_TARGET }}
           tags: ${{ inputs.IMAGE_NAME }}-${{ matrix.ARCH }}
           # Enable zstd compression (gzip is default)
-          outputs: type=image,compression=zstd
+          outputs: type=image,compression=zstd,force-compression=true,oci-mediatypes=true

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -56,8 +56,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver: docker-container
           endpoint: builders
+          buildkitd-flags: --debug --config /etc/buildkit/buildkitd.toml
       - name: Generate Build Args
         id: generate-build-args
         run: ci/compute-build-args.sh


### PR DESCRIPTION
This enables zstd compression for ci-imgs.

Closes #282.

_Do not merge until the 25.06 release is settled and has had a few days to marinate (ideally June 16)._