### PR TITLE
Use gha-tools retry scripts

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -19,6 +19,18 @@ ENV PYTHON_VERSION=${PYTHON_VER}
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+# Set apt policy configurations
+RUN <<EOF
+case "${LINUX_VER}" in
+  "ubuntu"*)
+    echo 'APT::Update::Error-Mode "any";' > /etc/apt/apt.conf.d/warnings-as-errors
+    echo 'APT::Acquire::Retries "10";' > /etc/apt/apt.conf.d/retries
+    echo 'APT::Acquire::https::Timeout "240";' > /etc/apt/apt.conf.d/https-timeout
+    echo 'APT::Acquire::http::Timeout "240";' > /etc/apt/apt.conf.d/http-timeout
+    ;;
+esac
+EOF
+
 # Install latest gha-tools
 RUN <<EOF
 case "${LINUX_VER}" in
@@ -109,9 +121,9 @@ case "${LINUX_VER}" in
         tzdata_pkgs=(tzdata)
     fi
 
-    rapids-retry apt-get update
-    rapids-retry apt-get upgrade -y
-    rapids-retry apt-get install -y --no-install-recommends \
+    apt-get update
+    apt-get upgrade -y
+    apt-get install -y --no-install-recommends \
       "${tzdata_pkgs[@]}"
 
     # Downgrade cuda-compat on CUDA 12.8 due to an upstream bug
@@ -159,10 +171,6 @@ SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 RUN <<EOF
 case "${LINUX_VER}" in
   "ubuntu"*)
-    echo 'APT::Update::Error-Mode "any";' > /etc/apt/apt.conf.d/warnings-as-errors
-    echo 'APT::Acquire::Retries "10";' > /etc/apt/apt.conf.d/retries
-    echo 'APT::Acquire::https::Timeout "240";' > /etc/apt/apt.conf.d/https-timeout
-    echo 'APT::Acquire::http::Timeout "240";' > /etc/apt/apt.conf.d/http-timeout
     apt-get update
     apt-get upgrade -y
     apt-get install -y --no-install-recommends \

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -20,6 +20,8 @@ ENV PYTHON_VERSION=${PYTHON_VER}
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # Set apt policy configurations
+# We bump up the number of retries and the timeouts for `apt`
+# Note that `dnf` defaults to 10 retries, so no additional configuration is required here
 RUN <<EOF
 case "${LINUX_VER}" in
   "ubuntu"*)

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -33,6 +33,10 @@ ENV PATH="/pyenv/bin:/pyenv/shims:$PATH"
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+# Install latest gha-tools
+RUN wget -q https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - \
+  | tar -xz -C /usr/local/bin
+
 RUN <<EOF
 case "${LINUX_VER}" in
   "ubuntu"*)
@@ -188,8 +192,8 @@ EOF
 
 RUN <<EOF
 pyenv global ${PYTHON_VER}
-python -m pip install --upgrade pip
-python -m pip install \
+rapids-pip-retry install --upgrade pip
+rapids-pip-retry install \
   'auditwheel>=6.2.0' \
   certifi \
   conda-package-handling \
@@ -202,13 +206,10 @@ python -m pip install \
 pyenv rehash
 EOF
 
-# Install latest gha-tools
-RUN wget -q https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
-
 # Install anaconda-client
 RUN <<EOF
-pip install git+https://github.com/Anaconda-Platform/anaconda-client
-pip cache purge
+rapids-pip-retry install git+https://github.com/Anaconda-Platform/anaconda-client
+rapids-pip-retry cache purge
 EOF
 
 # Install the AWS CLI

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -33,6 +33,18 @@ ENV PATH="/pyenv/bin:/pyenv/shims:$PATH"
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+# Set apt policy configurations
+RUN <<EOF
+case "${LINUX_VER}" in
+  "ubuntu"*)
+    echo 'APT::Update::Error-Mode "any";' > /etc/apt/apt.conf.d/warnings-as-errors
+    echo 'APT::Acquire::Retries "10";' > /etc/apt/apt.conf.d/retries
+    echo 'APT::Acquire::https::Timeout "240";' > /etc/apt/apt.conf.d/https-timeout
+    echo 'APT::Acquire::http::Timeout "240";' > /etc/apt/apt.conf.d/http-timeout
+    ;;
+esac
+EOF
+
 # Install latest gha-tools
 RUN <<EOF
 case "${LINUX_VER}" in
@@ -58,10 +70,6 @@ EOF
 RUN <<EOF
 case "${LINUX_VER}" in
   "ubuntu"*)
-    echo 'APT::Update::Error-Mode "any";' > /etc/apt/apt.conf.d/warnings-as-errors
-    echo 'APT::Acquire::Retries "10";' > /etc/apt/apt.conf.d/retries
-    echo 'APT::Acquire::https::Timeout "240";' > /etc/apt/apt.conf.d/https-timeout
-    echo 'APT::Acquire::http::Timeout "240";' > /etc/apt/apt.conf.d/http-timeout
     apt-get update -y
     apt-get install -y \
       autoconf \

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -34,6 +34,8 @@ ENV PATH="/pyenv/bin:/pyenv/shims:$PATH"
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # Set apt policy configurations
+# We bump up the number of retries and the timeouts for `apt`
+# Note that `dnf` defaults to 10 retries, so no additional configuration is required here
 RUN <<EOF
 case "${LINUX_VER}" in
   "ubuntu"*)

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -29,6 +29,18 @@ ENV PATH="/pyenv/bin:/pyenv/shims:$PATH"
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+# Set apt policy configurations
+RUN <<EOF
+case "${LINUX_VER}" in
+  "ubuntu"*)
+    echo 'APT::Update::Error-Mode "any";' > /etc/apt/apt.conf.d/warnings-as-errors
+    echo 'APT::Acquire::Retries "10";' > /etc/apt/apt.conf.d/retries
+    echo 'APT::Acquire::https::Timeout "240";' > /etc/apt/apt.conf.d/https-timeout
+    echo 'APT::Acquire::http::Timeout "240";' > /etc/apt/apt.conf.d/http-timeout
+    ;;
+esac
+EOF
+
 # Install latest gha-tools
 RUN <<EOF
 case "${LINUX_VER}" in
@@ -55,10 +67,6 @@ RUN <<EOF
 set -e
 case "${LINUX_VER}" in
   "ubuntu"*)
-    echo 'APT::Update::Error-Mode "any";' > /etc/apt/apt.conf.d/warnings-as-errors
-    echo 'APT::Acquire::Retries "10";' > /etc/apt/apt.conf.d/retries
-    echo 'APT::Acquire::https::Timeout "240";' > /etc/apt/apt.conf.d/https-timeout
-    echo 'APT::Acquire::http::Timeout "240";' > /etc/apt/apt.conf.d/http-timeout
     apt-get update
     apt-get install -y software-properties-common
     # update git > 2.17

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -30,6 +30,8 @@ ENV PATH="/pyenv/bin:/pyenv/shims:$PATH"
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # Set apt policy configurations
+# We bump up the number of retries and the timeouts for `apt`
+# Note that `dnf` defaults to 10 retries, so no additional configuration is required here
 RUN <<EOF
 case "${LINUX_VER}" in
   "ubuntu"*)

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -29,6 +29,10 @@ ENV PATH="/pyenv/bin:/pyenv/shims:$PATH"
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+# Install latest gha-tools
+RUN wget -q https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - \
+  | tar -xz -C /usr/local/bin
+
 RUN <<EOF
 set -e
 case "${LINUX_VER}" in
@@ -160,16 +164,12 @@ COPY --from=aws-cli /usr/local/bin/ /usr/local/bin/
 # update pip and install build tools
 RUN <<EOF
 pyenv global ${PYTHON_VER}
-python -m pip install --upgrade pip
-python -m pip install \
+rapids-pip-retry install --upgrade pip
+rapids-pip-retry install \
   certifi \
   'rapids-dependency-file-generator==1.*'
 pyenv rehash
 EOF
-
-# Install latest gha-tools
-RUN wget -q https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - \
-  | tar -xz -C /usr/local/bin
 
 # git safe directory
 RUN git config --system --add safe.directory '*'


### PR DESCRIPTION
This PR installs `gha-tools` first, rather than last, and ensures that conda/pip commands use the retrying equivalent to minimize risk of failures.

A [recent failure](https://github.com/rapidsai/ci-imgs/actions/runs/15721271197/job/44302836709#step:9:2040) looked like:

```
 15.66 CondaHTTPError: HTTP 502 BAD GATEWAY for url <https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-cpp-0.8.0-h5ad3122_0.conda>
 15.66 Elapsed: 00:03.035743
 15.66 CF-RAY: 9516dd6ecb952a9c-CMH
 15.66
 15.66 An HTTP error occurred when trying to retrieve this URL.
 15.66 HTTP errors are often intermittent, and a simple retry will get you on your way.
```
