### PR TITLE
Rehash after installing anaconda

### DIFF
--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -240,6 +240,7 @@ EOF
 RUN <<EOF
 rapids-pip-retry install git+https://github.com/Anaconda-Platform/anaconda-client
 rapids-pip-retry cache purge
+pyenv rehash
 EOF
 
 # Install the AWS CLI


### PR DESCRIPTION
Without this pyenv does not guarantee that shell commands will be available post installation. It looks like we have been getting lucky so far (perhaps some of the retrying changes changed some subtle pip ordering that made this work before) but the rehash is the right solution. All of RAPIDS CI is currently failing to upload wheels without this.