### PR TITLE
Clean up from CUDA 12.9 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ To build the dockerfiles locally, you may use the following snippets:
 
 ```sh
 export LINUX_VER=ubuntu24.04
-export CUDA_VER=12.8.0
-export PYTHON_VER=3.12
+export CUDA_VER=12.9.1
+export PYTHON_VER=3.13
 export ARCH=amd64
 export IMAGE_REPO=ci-conda
 docker build $(ci/compute-build-args.sh) -f ci-conda.Dockerfile context/

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -38,7 +38,7 @@ RUN <<EOF
 case "${LINUX_VER}" in
   "ubuntu"*)
     i=0; until apt-get update -y; do ((++i >= 5)) && break; sleep 10; done
-    apt-get install -y wget
+    apt-get install -y --no-install-recommends wget
     wget -q https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
     apt-get purge -y wget && apt-get autoremove -y
     rm -rf /var/lib/apt/lists/*
@@ -128,12 +128,6 @@ case "${LINUX_VER}" in
     apt-get upgrade -y
     apt-get install -y --no-install-recommends \
       "${tzdata_pkgs[@]}"
-
-    # Downgrade cuda-compat on CUDA 12.8 due to an upstream bug
-    if [[ "${CUDA_VER}" == "12.8"* ]]; then
-      apt-get install -y --allow-downgrades cuda-compat-12-8=570.148.08-0ubuntu1
-      apt-mark hold cuda-compat-12-8
-    fi
 
     rm -rf "/var/lib/apt/lists/*"
     ;;

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -52,7 +52,7 @@ RUN <<EOF
 case "${LINUX_VER}" in
   "ubuntu"*)
     i=0; until apt-get update -y; do ((++i >= 5)) && break; sleep 10; done
-    apt-get install -y wget
+    apt-get install -y --no-install-recommends wget
     wget -q https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
     apt-get purge -y wget && apt-get autoremove -y
     rm -rf /var/lib/apt/lists/*

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -48,7 +48,7 @@ RUN <<EOF
 case "${LINUX_VER}" in
   "ubuntu"*)
     i=0; until apt-get update -y; do ((++i >= 5)) && break; sleep 10; done
-    apt-get install -y wget
+    apt-get install -y --no-install-recommends wget
     wget -q https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
     apt-get purge -y wget && apt-get autoremove -y
     rm -rf /var/lib/apt/lists/*
@@ -112,12 +112,6 @@ case "${LINUX_VER}" in
       xz-utils \
       zlib1g-dev
     update-ca-certificates
-
-    # Downgrade cuda-compat on CUDA 12.8 due to an upstream bug
-    if [[ "${CUDA_VER}" == "12.8"* ]]; then
-      apt-get install -y --allow-downgrades cuda-compat-12-8=570.148.08-0ubuntu1
-      apt-mark hold cuda-compat-12-8
-    fi
 
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
     ;;


### PR DESCRIPTION
Did some cleanup from CUDA 12.9 changes:

- Added `-no-install-recommends` per @jameslamb's suggestion
- Updated README
- Removed workaround for CUDA 12.8, no longer needed
