### PR TITLE
double-tag images (with and without RAPIDS version)

### DIFF
--- a/.github/workflows/build-and-publish-images.yaml
+++ b/.github/workflows/build-and-publish-images.yaml
@@ -80,4 +80,5 @@ jobs:
           IMAGE_REPO: ${{ matrix.IMAGE_REPO }}
           BUILD_TYPE: ${{ inputs.build_type }}
           IMAGE_NAME: ${{ matrix.IMAGE_NAME }}
+          IMAGE_NAME_NO_RAPIDS_VERSION: ${{ matrix.IMAGE_NAME_NO_RAPIDS_VERSION }}
         run: ci/create-multiarch-manifest.sh

--- a/README.md
+++ b/README.md
@@ -2,9 +2,52 @@
 
 This repository includes the following CI images for RAPIDS:
 
-- `ci-conda` images are conda CI images used for building RAPIDS.
-- `ci-wheel` images are for building manylinux-compliant wheels. They are also used to build pure-Python wheels, and for publishing wheels with twine.
-- `citestwheel` images are for running wheel tests.
+- [`rapidsai/ci-conda`](https://hub.docker.com/r/rapidsai/ci-conda/tags): for building and testing RAPIDS `conda` packages
+- [`rapidsai/ci-wheel`](https://hub.docker.com/r/rapidsai/ci-wheel/tags): for building and publishing RAPIDS wheels (including pure-Python and manylinux-compliant wheels)
+- [`rapidsai/citestwheel`](https://hub.docker.com/r/rapidsai/citestwheel/tags): for testing wheels
+- [`rapidsai/miniforge-cuda`](https://hub.docker.com/r/rapidsai/citestwheel/tags): base image for `conda`-based images here, and for user-facing RAPIDS images like https://github.com/rapidsai/docker
+
+## Tagging Strategy
+
+All images are double-published with the following tags:
+
+```text
+:{rapids_version}-cuda{cuda_version}-{operating_system}-py{python_version}
+:cuda{cuda_version}-{operating_system}-py{python_version}
+```
+
+One particular combination is also chosen for `latest` tags like these:
+
+```text
+:{rapids_version}-latest
+:latest
+```
+
+For example, during the 25.10 release the following might all point to the same image:
+
+```text
+rapidsai/ci-conda:25.10-cuda12.9.1-ubuntu24.04-py3.13
+rapidsai/ci-conda:cuda12.9.1-ubuntu24.04-py3.13
+rapidsai/ci-conda:25.10-latest
+rapidsai/ci-conda:latest
+```
+
+But starting with the 25.12 release...
+
+```text
+# these images are unchanged
+rapidsai/ci-conda:25.10-cuda12.9.1-ubuntu24.04-py3.13
+rapidsai/ci-conda:25.10-latest
+
+# these now point to 25.12
+rapidsai/ci-conda:cuda12.9.1-ubuntu24.04-py3.13
+rapidsai/ci-conda:latest
+```
+
+RAPIDS projects and others tightly coupled to RAPIDS releases should use the images prefixed with `{rapids_version}-`.
+
+Other projects that aren't as tightly coupled to RAPIDS may want to use those without `{rapids_version}-`, to automatically
+pull in bug fixes, new features, etc. without needing to manually update tags as frequently as RAPIDS releases.
 
 ## `latest` tag
 

--- a/ci/create-multiarch-manifest.sh
+++ b/ci/create-multiarch-manifest.sh
@@ -16,8 +16,14 @@ for arch in $(echo "${ARCHES}" | jq .[] -r); do
   source_tags+=("${tag}-${arch}")
 done
 
+# create/update manifests for RAPIDS-versioned images
 docker manifest create "${tag}" "${source_tags[@]}"
 docker manifest push "${tag}"
+
+# create/update manifests for non-RAPIDS-versioned images
+docker manifest create "${IMAGE_NAME_NO_RAPIDS_VERSION}" "${source_tags[@]}"
+docker manifest push "${IMAGE_NAME_NO_RAPIDS_VERSION}"
+
 if [[
   "${LATEST_UBUNTU_VER}" == "${LINUX_VER}" &&
   "${LATEST_CUDA_VER}" == "${CUDA_VER}" &&
@@ -26,9 +32,14 @@ if [[
   # only create a 'latest' manifest if it is a non-PR workflow.
   MANIFEST_TAG="${RAPIDS_VERSION_MAJOR_MINOR}-latest"
   if [[ "${BUILD_TYPE}" != "pull-request" ]]; then
+    # create a "latest"
+    docker manifest create "rapidsai/${IMAGE_REPO}:latest" "${source_tags[@]}"
+    docker manifest push "rapidsai/${IMAGE_REPO}:latest"
+
+    # create a {rapids_version}-latest
     docker manifest create "rapidsai/${IMAGE_REPO}:${MANIFEST_TAG}" "${source_tags[@]}"
     docker manifest push "rapidsai/${IMAGE_REPO}:${MANIFEST_TAG}"
   else
-    echo "Skipping '${MANIFEST_TAG}' manifest creation for PR workflow."
+    echo "Skipping 'latest' and '${MANIFEST_TAG}' manifest creation for PR workflow."
   fi
 fi

--- a/ci/create-multiarch-manifest.sh
+++ b/ci/create-multiarch-manifest.sh
@@ -29,14 +29,14 @@ if [[
   "${LATEST_CUDA_VER}" == "${CUDA_VER}" &&
   "${LATEST_PYTHON_VER}" == "${PYTHON_VER}"
 ]]; then
-  # only create a 'latest' manifest if it is a non-PR workflow.
+  # only create/update ':latest' manifest if it is a non-PR workflow.
   MANIFEST_TAG="${RAPIDS_VERSION_MAJOR_MINOR}-latest"
   if [[ "${BUILD_TYPE}" != "pull-request" ]]; then
-    # create a "latest"
+    # create/update ":latest"
     docker manifest create "rapidsai/${IMAGE_REPO}:latest" "${source_tags[@]}"
     docker manifest push "rapidsai/${IMAGE_REPO}:latest"
 
-    # create a {rapids_version}-latest
+    # create/update ":{rapids_version}-latest"
     docker manifest create "rapidsai/${IMAGE_REPO}:${MANIFEST_TAG}" "${source_tags[@]}"
     docker manifest push "rapidsai/${IMAGE_REPO}:${MANIFEST_TAG}"
   else


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/187

#287 added the RAPIDS version to image tags, like this:

```text
# before
rapidsai/citestwheel:cuda12.8.0-ubuntu24.04-py3.10

# after
rapidsai/citestwheel:25.08-cuda12.8.0-ubuntu24.04-py3.10
```

This allows us to merge breaking changes to the images for one RAPIDS release without impacting the ability to build and test older releases, which is great 🤩 

But it also means that other projects depending on these images which are not as tightly coupled to RAPIDS now have to think about what RAPIDS release(s) are active.

This proposes restoring the un-RAPIDS-versioned images via double-tagging. Please see https://github.com/rapidsai/build-planning/issues/187#issuecomment-2981069294 for details.

## Notes for Reviewers

### How I tested this

Tested the GitHub Actions changes with `actionlint` (which did catch a mistake I'd made!)

```shell
actionlint .github/workflows/*
```

Checked the matrix entries like this:

```shell
# with https://github.com/rapidsai/gha-tools cloned to ~/repos/gha-tools

PATH="${HOME}/repos/gha-tools/tools:${PATH}" \
BUILD_TYPE=branch \
  ./ci/compute-matrix.sh \
| jq .
```

Saw the same number of total images, but a new `IMAGE_NAME_NO_RAPIDS_VERSION` added to each matrix entry (with correct values).

```json
{
  [
    ...
    {
      "CUDA_VER": "12.9.1",
      "PYTHON_VER": "3.13",
      "LINUX_VER": "rockylinux8",
      "IMAGE_REPO": "citestwheel",
      "DOCKERFILE": "citestwheel.Dockerfile",
      "DOCKER_TARGET": "",
      "ARCHES": [
        "amd64",
        "arm64"
      ],
      "IMAGE_NAME": "rapidsai/citestwheel:25.10-cuda12.9.1-rockylinux8-py3.13",
      "IMAGE_NAME_NO_RAPIDS_VERSION": "rapidsai/citestwheel:cuda12.9.1-rockylinux8-py3.13"
    }
  ]
}
```
