### PR TITLE
Install yq and awscli from binaries instead of Docker

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -267,6 +267,7 @@ mv /tmp/yq /usr/bin/yq
 chmod +x /usr/bin/yq
 rm -f /tmp/yq
 
+# ref: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html#getting-started-install-instructions
 rapids-retry curl -o /tmp/awscliv2.zip \
   -L "https://awscli.amazonaws.com/awscli-exe-linux-${REAL_ARCH}-${AWS_CLI_VER}.zip"
 unzip -q /tmp/awscliv2.zip -d /tmp

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -265,7 +265,6 @@ rm -rf gh_*
 rapids-retry wget -q https://github.com/mikefarah/yq/releases/download/v${YQ_VER}/yq_linux_${CPU_ARCH} -O /tmp/yq
 mv /tmp/yq /usr/bin/yq
 chmod +x /usr/bin/yq
-rm -f /tmp/yq
 
 # ref: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html#getting-started-install-instructions
 rapids-retry curl -o /tmp/awscliv2.zip \

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -187,6 +187,7 @@ EOF
 
 # Install sccache
 ARG SCCACHE_VER=notset
+
 RUN <<EOF
 rapids-retry curl -o /tmp/sccache.tar.gz \
   -L "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/sccache-v${SCCACHE_VER}-"${REAL_ARCH}"-unknown-linux-musl.tar.gz"
@@ -196,6 +197,7 @@ chmod +x /usr/bin/sccache
 EOF
 
 # Download and install awscli
+# Needed to download wheels for running tests
 ARG AWS_CLI_VER=notset
 RUN <<EOF
 rapids-retry curl -o /tmp/awscliv2.zip \

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -202,6 +202,7 @@ EOF
 # Needed to download wheels for running tests
 ARG AWS_CLI_VER=notset
 RUN <<EOF
+# ref: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html#getting-started-install-instructions
 rapids-retry curl -o /tmp/awscliv2.zip \
   -L "https://awscli.amazonaws.com/awscli-exe-linux-${REAL_ARCH}-${AWS_CLI_VER}.zip"
 unzip -q /tmp/awscliv2.zip -d /tmp

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -100,6 +100,7 @@ case "${LINUX_VER}" in
       openssh-client \
       protobuf-compiler \
       software-properties-common \
+      unzip \
       wget \
       yasm \
       zip \
@@ -143,6 +144,7 @@ case "${LINUX_VER}" in
       readline-devel \
       sqlite \
       sqlite-devel \
+      unzip \
       wget \
       which \
       xz \

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -132,6 +132,7 @@ case "${LINUX_VER}" in
       readline-devel \
       sqlite \
       sqlite-devel \
+      unzip \
       wget \
       which \
       xz \

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -170,6 +170,7 @@ EOF
 ARG AWS_CLI_VER=notset
 ARG REAL_ARCH=notset
 RUN <<EOF
+# ref: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html#getting-started-install-instructions
 rapids-retry curl -o /tmp/awscliv2.zip \
   -L "https://awscli.amazonaws.com/awscli-exe-linux-${REAL_ARCH}-${AWS_CLI_VER}.zip"
 unzip -q /tmp/awscliv2.zip -d /tmp

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -167,6 +167,7 @@ EOF
 
 # Download and install awscli
 ARG AWS_CLI_VER=notset
+ARG REAL_ARCH=notset
 RUN <<EOF
 rapids-retry curl -o /tmp/awscliv2.zip \
   -L "https://awscli.amazonaws.com/awscli-exe-linux-${REAL_ARCH}-${AWS_CLI_VER}.zip"

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
       "description": "Update low-risk CLI tools together",
       "groupName": "cli-tools",
       "matchPackageNames": [
-        "/^(amazon/aws-cli|cli/cli|codecov-cli|mikefarah/yq)$/"
+        "/^(aws/aws-cli|cli/cli|codecov-cli|mikefarah/yq)$/"
       ]
     }
   ],

--- a/versions.yaml
+++ b/versions.yaml
@@ -9,9 +9,9 @@ SCCACHE_VER: 0.7.7
 GH_CLI_VER: 2.76.2
 # renovate: datasource=pypi depName=codecov-cli
 CODECOV_VER: 11.1.0
-# renovate: datasource=docker depName=mikefarah/yq versioning=docker
+# renovate: datasource=github-releases depName=mikefarah/yq
 YQ_VER: 4.47.1
-# renovate: datasource=docker depName=amazon/aws-cli versioning=docker
+# renovate: datasource=github-releases depName=aws/aws-cli
 AWS_CLI_VER: 2.28.1
 # renovate: datasource=docker depName=condaforge/miniforge3 versioning=docker
 MINIFORGE_VER: 24.11.3-0


### PR DESCRIPTION
Towards https://github.com/rapidsai/build-infra/issues/288

Instead of installing AWS CLI and yq from Docker images as base, these changes download the official binaries for both these packages and install them, reducing the number of base images being used in the Docker build. 