### PR TITLE
update 'latest' to CUDA 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ One particular combination is also chosen for `latest` tags like these:
 For example, during the 25.10 release the following might all point to the same image:
 
 ```text
-rapidsai/ci-conda:25.10-cuda12.9.1-ubuntu24.04-py3.13
-rapidsai/ci-conda:cuda12.9.1-ubuntu24.04-py3.13
+rapidsai/ci-conda:25.10-cuda13.0.0-ubuntu24.04-py3.13
+rapidsai/ci-conda:cuda13.0.0-ubuntu24.04-py3.13
 rapidsai/ci-conda:25.10-latest
 rapidsai/ci-conda:latest
 ```
@@ -36,11 +36,11 @@ But starting with the 25.12 release...
 
 ```text
 # these images are unchanged
-rapidsai/ci-conda:25.10-cuda12.9.1-ubuntu24.04-py3.13
+rapidsai/ci-conda:25.10-cuda13.0.0-ubuntu24.04-py3.13
 rapidsai/ci-conda:25.10-latest
 
 # these now point to 25.12
-rapidsai/ci-conda:cuda12.9.1-ubuntu24.04-py3.13
+rapidsai/ci-conda:cuda13.0.0-ubuntu24.04-py3.13
 rapidsai/ci-conda:latest
 ```
 
@@ -59,7 +59,7 @@ To build the dockerfiles locally, you may use the following snippets:
 
 ```sh
 export LINUX_VER=ubuntu24.04
-export CUDA_VER=12.9.1
+export CUDA_VER=13.0.0
 export PYTHON_VER=3.13
 export ARCH=amd64
 export IMAGE_REPO=ci-conda

--- a/latest.yaml
+++ b/latest.yaml
@@ -3,19 +3,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # Define the values used for the "latest" tag
 miniforge-cuda:
-  CUDA_VER: "12.9.1"
+  CUDA_VER: "13.0.0"
   PYTHON_VER: "3.13"
   LINUX_VER: "ubuntu24.04"
 ci-conda:
-  CUDA_VER: "12.9.1"
+  CUDA_VER: "13.0.0"
   PYTHON_VER: "3.13"
   LINUX_VER: "ubuntu24.04"
 ci-wheel:
-  CUDA_VER: "12.9.1"
+  CUDA_VER: "13.0.0"
   PYTHON_VER: "3.13"
   # Wheels should always be built with the oldest supported glibc version
   LINUX_VER: "rockylinux8"
 citestwheel:
-  CUDA_VER: "12.9.1"
+  CUDA_VER: "13.0.0"
   PYTHON_VER: "3.13"
   LINUX_VER: "ubuntu24.04"


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/208

Updates the `:latest` and `:25.10-latest` tags to CUDA 13.0.0.

## Notes for Reviewers

### is this safe to merge?

Once these are in, I think yes:

* [x] https://github.com/NVIDIA/cuopt/pull/366
* [x] https://github.com/rapidsai/cugraph-gnn/pull/286

At that point, the only thing it should affect are docs builds across repos that are already supporting CUDA 13 in all their other conda-based tests.