### PR TITLE
fix(rockylinux): run `dnf makecache` so indexes aren't stale

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -44,7 +44,9 @@ case "${LINUX_VER}" in
     rm -rf /var/lib/apt/lists/*
     ;;
   "rockylinux"*)
-    dnf makecache
+    dnf clean all
+    rm -rf /var/cache/dnf/*
+    dnf --refresh makecache
     dnf install -y wget
     wget -q https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
     dnf remove -y wget
@@ -133,7 +135,9 @@ case "${LINUX_VER}" in
     rm -rf "/var/lib/apt/lists/*"
     ;;
   "rockylinux"*)
-    dnf makecache
+    dnf clean all
+    rm -rf /var/cache/dnf/*
+    dnf --refresh makecache
     dnf update -y
     dnf clean all
     ;;
@@ -180,8 +184,11 @@ case "${LINUX_VER}" in
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
     ;;
   "rockylinux"*)
-    dnf makecache
+    dnf clean all
+    rm -rf /var/cache/dnf/*
+    dnf --refresh makecache
     dnf -y update
+    dnf clean all
     dnf -y install --setopt=install_weak_deps=False \
       ca-certificates \
       file \

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -57,7 +57,9 @@ case "${LINUX_VER}" in
     rm -rf /var/lib/apt/lists/*
     ;;
   "rockylinux"*)
-    dnf makecache
+    dnf clean all
+    rm -rf /var/cache/dnf/*
+    dnf --refresh makecache
     dnf install -y wget
     wget -q https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
     dnf remove -y wget
@@ -117,7 +119,9 @@ case "${LINUX_VER}" in
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
     ;;
   "rockylinux"*)
-    dnf makecache
+    dnf clean all
+    rm -rf /var/cache/dnf/*
+    dnf --refresh makecache
     dnf update -y
     dnf install -y epel-release
     dnf update -y

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -53,7 +53,9 @@ case "${LINUX_VER}" in
     rm -rf /var/lib/apt/lists/*
     ;;
   "rockylinux"*)
-    dnf makecache
+    dnf clean all
+    rm -rf /var/cache/dnf/*
+    dnf --refresh makecache
     dnf install -y wget
     wget -q https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
     dnf remove -y wget
@@ -116,7 +118,9 @@ case "${LINUX_VER}" in
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
     ;;
   "rockylinux"*)
-    dnf makecache
+    dnf clean all
+    rm -rf /var/cache/dnf/*
+    dnf --refresh makecache
     dnf update -y
     dnf install -y epel-release
     dnf update -y


### PR DESCRIPTION
There are several 404s in the build jobs here: https://github.com/rapidsai/ci-imgs/actions/runs/18690449618

Some of them resolve on a restart, but the ones that fail hit a 404 for every single mirror, which seems weird.  Adding in `dnf makecache` to try to keep the indexes fresh.
