### PR TITLE
Pin `openssl<3.5.3` to fix mamba hangs in CI

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -77,7 +77,7 @@ umask 002
 echo 'libxml2<2.14.0' >> /opt/conda/conda-meta/pinned
 
 # Pin openssl to workaround install timeouts issue
-echo 'openssl==3.5.4' >> /opt/conda/conda-meta/pinned
+echo 'openssl<3.5.3' >> /opt/conda/conda-meta/pinned
 
 # update everything before other environment changes, to ensure mixing
 # an older conda with newer packages still works well


### PR DESCRIPTION
I do not know why this fixes the mamba hangs we're seeing in CI, but it does.