### PR TITLE
fix(wheel): use release of anaconda-client instead of upstream `main`

### DIFF
--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -251,7 +251,7 @@ EOF
 
 # Install anaconda-client
 RUN <<EOF
-rapids-pip-retry install git+https://github.com/Anaconda-Platform/anaconda-client
+rapids-pip-retry install anaconda-client
 rapids-pip-retry cache purge
 pyenv rehash
 EOF


### PR DESCRIPTION
We've been installing `anaconda-client` from the upstream `main` for as long as we've been using it in this image.

That led to a breakage when they made a breaking change between releases.  There is no reason for us to track `main` with this, we can install from PyPI.

Representative failure in RAFT: https://github.com/rapidsai/raft/actions/runs/19159556298/job/54767386031

```
  File "/pyenv/versions/3.13.9/lib/python3.13/site-packages/binstar_client/commands/login.py", line 15, in <module>
    from anaconda_auth.config import AnacondaAuthSite
ImportError: cannot import name 'AnacondaAuthSite' from 'anaconda_auth.config' (/pyenv/versions/3.13.9/lib/python3.13/site-packages/anaconda_auth/config.py)
```
