### PR TITLE
refactor(deps): remove `openssl` pin `<3.5.3`

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -75,9 +75,6 @@ umask 002
 # xref: https://github.com/conda-forge/libxml2-feedstock/issues/145
 echo 'libxml2<2.14.0' >> /opt/conda/conda-meta/pinned
 
-# Pin openssl to workaround install timeouts issue
-echo 'openssl<3.5.3' >> /opt/conda/conda-meta/pinned
-
 # update everything before other environment changes, to ensure mixing
 # an older conda with newer packages still works well
 rapids-mamba-retry update --all -y -n base


### PR DESCRIPTION
This is breaking our builds downstream in `rapidsai/docker` -- the hope
is that the timeout issues are resolved.

Tracking some of this in rapidsai/ops#4361

xref #313
xref #316

Note that `3.6.0` has been released since the initial hang issue was identified, so this isn't _purely_ a hope-based change.
