### PR TITLE
Build python `3.14` images

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -9,6 +9,7 @@ PYTHON_VER:
   - "3.11"
   - "3.12"
   - "3.13"
+  - "3.14"
 LINUX_VER:
   - "ubuntu22.04"
   - "ubuntu24.04"


### PR DESCRIPTION
Builds CI images for python 3.14.