### PR TITLE
ci-wheel: combine pip install calls

### DIFF
--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -237,7 +237,7 @@ pyenv global ${PYTHON_VER}
 # use so should be compatible with `pyenv`
 rapids-pip-retry install --upgrade pip
 rapids-pip-retry install \
-  'anaconda-client>=1.13.0'
+  'anaconda-client>=1.13.0' \
   'auditwheel>=6.2.0' \
   certifi \
   conda-package-handling \


### PR DESCRIPTION
As of #320, we now get `anaconda-client` via a `pip install`.

This proposes moving that into the other `pip install` used to install things into the `ci-wheel` images.

Benefits of having a single, consolidated `pip install`:

* reduced risk of broken environments (i.e. dependency conflicts will be loud errors)
* simpler Dockerfile
* fewer layers = smaller image