### PR TITLE
ci-conda: use prefix mirror of conda-forge

### DIFF
--- a/context/condarc.tmpl
+++ b/context/condarc.tmpl
@@ -5,6 +5,10 @@ channels:
   - rapidsai
   - rapidsai-nightly
   - conda-forge
+# TODO: remove 'custom_multichannels' when https://github.com/conda/infrastructure/issues/1254 is resolved
+custom_multichannels:
+  conda-forge:
+    - https://prefix.dev/conda-forge
 conda-build:
   pkg_format: '2'
   set_build_id: false


### PR DESCRIPTION
Proposes temporarily using prefix's mirror of `conda-forge` in RAPIDS CI, to work around the ongoing issue with the main `conda-forge` channel (https://github.com/conda/infrastructure/issues/1254).

h/t @TomAugspurger for the suggestion

## Notes for Reviewers

### How I tested this

Over on https://github.com/rapidsai/cudf/pull/20748, I added the following to a bunch of scripts that use `conda` / `mamba`:

```shell
conda config --append 'custom_multichannels.conda-forge' 'https://prefix.dev/conda-forge'
```

Saw jobs that had been failing succeed, and saw the prefix mirror used.

```text
...
  + bzip2                        1.0.8  hda65f42_8              prefix.dev/conda-forge     260kB
  + c-ares                      1.34.5  hb9d3cd8_0              prefix.dev/conda-forge     207kB
  + ca-certificates         2025.11.12  hbd8a1cb_0              prefix.dev/conda-forge     152kB
  + cmake                        4.2.0  hc85cc9f_0              prefix.dev/conda-forge      22MB
  + cuda-cudart                13.0.96  hecca717_0              prefix.dev/conda-forge      24kB
...
```

([build link](https://github.com/rapidsai/cudf/actions/runs/19839750040/job/56846227759?pr=20748))