### PR TITLE
Remove sccache

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -264,20 +264,13 @@ rapids-mamba-retry install -y \
 conda clean -aiptfy
 EOF
 
-# Install sccache, gh cli, yq, and awscli
-ARG SCCACHE_VER=notset
+# Install gh cli, yq, and awscli
 ARG REAL_ARCH=notset
 ARG GH_CLI_VER=notset
 ARG CPU_ARCH=notset
 ARG YQ_VER=notset
 ARG AWS_CLI_VER=notset
 RUN <<EOF
-rapids-retry curl -o /tmp/sccache.tar.gz \
-  -L "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/sccache-v${SCCACHE_VER}-"${REAL_ARCH}"-unknown-linux-musl.tar.gz"
-tar -C /tmp -xvf /tmp/sccache.tar.gz
-mv "/tmp/sccache-v${SCCACHE_VER}-"${REAL_ARCH}"-unknown-linux-musl/sccache" /usr/bin/sccache
-chmod +x /usr/bin/sccache
-rm -rf /tmp/sccache.tar.gz "/tmp/sccache-v${SCCACHE_VER}-"${REAL_ARCH}"-unknown-linux-musl"
 
 rapids-retry wget -q https://github.com/cli/cli/releases/download/v${GH_CLI_VER}/gh_${GH_CLI_VER}_linux_${CPU_ARCH}.tar.gz
 tar -xf gh_*.tar.gz

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -186,17 +186,6 @@ mv gh_*/bin/gh /usr/local/bin
 rm -rf gh_*
 EOF
 
-# Install sccache
-ARG SCCACHE_VER=notset
-
-RUN <<EOF
-rapids-retry curl -o /tmp/sccache.tar.gz \
-  -L "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/sccache-v${SCCACHE_VER}-"${REAL_ARCH}"-unknown-linux-musl.tar.gz"
-tar -C /tmp -xvf /tmp/sccache.tar.gz
-mv "/tmp/sccache-v${SCCACHE_VER}-"${REAL_ARCH}"-unknown-linux-musl/sccache" /usr/bin/sccache
-chmod +x /usr/bin/sccache
-EOF
-
 # Download and install awscli
 # Needed to download wheels for running tests
 ARG AWS_CLI_VER=notset

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,9 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-# 'sccache' is intentionally not auto-updated by renovate. Such updates
-# have the potential to significantly disrupt RAPIDS development, so we
-# prefer sticking with a stable version until a specific reason to update arises.
-SCCACHE_VER: 0.7.7
 # renovate: datasource=github-releases depName=cli/cli
 GH_CLI_VER: 2.82.1
 # renovate: datasource=pypi depName=codecov-cli


### PR DESCRIPTION
We do not want to use the mozilla/sccache (upstream) version of sccache. We should always be using the rapids/sccache fork which contains several required features. That is installed by https://github.com/rapidsai/gha-tools/blob/main/tools/rapids-configure-sccache, which should be called with `source rapids-configure-sccache` in all CI workflows that perform compilation.
