### PR TITLE
Revert "ci-conda: use prefix mirror of conda-forge (#331)"

### DIFF
--- a/context/condarc.tmpl
+++ b/context/condarc.tmpl
@@ -5,10 +5,6 @@ channels:
   - rapidsai
   - rapidsai-nightly
   - conda-forge
-# TODO: remove 'custom_multichannels' when https://github.com/conda/infrastructure/issues/1254 is resolved
-custom_multichannels:
-  conda-forge:
-    - https://prefix.dev/conda-forge
 conda-build:
   pkg_format: '2'
   set_build_id: false


### PR DESCRIPTION
Reverts #331

The incident with conda-forge that led to #331 has been resolved, so we do not need to keep depending on prefix's conda-forge mirror.

## Notes for Reviewers

### How I tested this

Put the following into conda-based CI scripts in a `cugraph` PR (https://github.com/rapidsai/cugraph/pull/5356)

```shell
conda config --file /opt/conda/.condarc --remove-key custom_multichannels
```

And saw jobs succeed and use only the conda-forge main channel (not the prefix mirror)

```text
...
  + _libgcc_mutex                           0.1  conda_forge                   conda-forge               3kB
  + _openmp_mutex                           4.5  2_gnu                         conda-forge              24kB
  + attr                                  2.5.2  h39aace5_0                    conda-forge              68kB
  + bzip2                                 1.0.8  hda65f42_8                    conda-forge             260kB
  + c-ares                               1.34.5  hb9d3cd8_0                    conda-forge             207kB
...
```

([conda-cpp-tests link](https://github.com/rapidsai/cugraph/actions/runs/19872962730/job/56955273132?pr=5356))