### PR TITLE
Pass GH_TOKEN as Docker build secret for sccache download

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -90,3 +90,7 @@ jobs:
           # https://github.com/docker/build-push-action/issues/755
           provenance: false
           sbom: false
+          # Pass GH_TOKEN as a secret for gh CLI authentication during build
+          # This allows rapids-install-sccache to download from GitHub releases
+          secrets: |
+            GH_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -57,17 +57,21 @@ The `latest` image tags are controlled by the values in `latest.yaml`.
 
 ## Building the dockerfiles locally
 
-To build the dockerfiles locally, you may use the following snippets:
+To build the dockerfiles locally, you may use the following snippets.
+
+The `ci-conda` and `ci-wheel` images require a GitHub token to download sccache releases.
+If you have the `gh` CLI installed and authenticated, you can use `gh auth token` to get your token:
 
 ```sh
 export LINUX_VER=ubuntu24.04
 export CUDA_VER=13.0.2
 export PYTHON_VER=3.13
 export ARCH=amd64
+export GH_TOKEN=$(gh auth token)
 export IMAGE_REPO=ci-conda
-docker build $(ci/compute-build-args.sh) -f ci-conda.Dockerfile context/
+docker build $(ci/compute-build-args.sh) --secret id=GH_TOKEN -f ci-conda.Dockerfile context/
 export IMAGE_REPO=ci-wheel
-docker build $(ci/compute-build-args.sh) -f ci-wheel.Dockerfile context/
+docker build $(ci/compute-build-args.sh) --secret id=GH_TOKEN -f ci-wheel.Dockerfile context/
 export IMAGE_REPO=citestwheel
 docker build $(ci/compute-build-args.sh) -f citestwheel.Dockerfile context/
 ```

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -19,13 +19,13 @@ SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 ARG SCCACHE_VER=notset
 ARG GH_CLI_VER=notset
 ARG CPU_ARCH=notset
-RUN <<EOF
+RUN --mount=type=secret,id=GH_TOKEN <<EOF
   i=0; until apt-get update -y; do ((++i >= 5)) && break; sleep 10; done
   apt-get install -y --no-install-recommends wget
   wget -q https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
   wget -q https://github.com/cli/cli/releases/download/v${GH_CLI_VER}/gh_${GH_CLI_VER}_linux_${CPU_ARCH}.tar.gz
   tar -xf gh_*.tar.gz && mv gh_*/bin/gh /usr/local/bin && rm -rf gh_*
-  SCCACHE_VERSION="${SCCACHE_VER}" rapids-install-sccache
+  GH_TOKEN=$(cat /run/secrets/GH_TOKEN) SCCACHE_VERSION="${SCCACHE_VER}" rapids-install-sccache
   apt-get purge -y wget && apt-get autoremove -y
   rm -rf /var/lib/apt/lists/*
 EOF
@@ -74,7 +74,7 @@ EOF
 ARG SCCACHE_VER=notset
 ARG GH_CLI_VER=notset
 ARG CPU_ARCH=notset
-RUN <<EOF
+RUN --mount=type=secret,id=GH_TOKEN <<EOF
 case "${LINUX_VER}" in
   "ubuntu"*)
     i=0; until apt-get update -y; do ((++i >= 5)) && break; sleep 10; done
@@ -82,7 +82,7 @@ case "${LINUX_VER}" in
     wget -q https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
     wget -q https://github.com/cli/cli/releases/download/v${GH_CLI_VER}/gh_${GH_CLI_VER}_linux_${CPU_ARCH}.tar.gz
     tar -xf gh_*.tar.gz && mv gh_*/bin/gh /usr/local/bin && rm -rf gh_*
-    SCCACHE_VERSION="${SCCACHE_VER}" rapids-install-sccache
+    GH_TOKEN=$(cat /run/secrets/GH_TOKEN) SCCACHE_VERSION="${SCCACHE_VER}" rapids-install-sccache
     apt-get purge -y wget && apt-get autoremove -y
     rm -rf /var/lib/apt/lists/*
     ;;
@@ -91,7 +91,7 @@ case "${LINUX_VER}" in
     wget -q https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
     wget -q https://github.com/cli/cli/releases/download/v${GH_CLI_VER}/gh_${GH_CLI_VER}_linux_${CPU_ARCH}.tar.gz
     tar -xf gh_*.tar.gz && mv gh_*/bin/gh /usr/local/bin && rm -rf gh_*
-    SCCACHE_VERSION="${SCCACHE_VER}" rapids-install-sccache
+    GH_TOKEN=$(cat /run/secrets/GH_TOKEN) SCCACHE_VERSION="${SCCACHE_VER}" rapids-install-sccache
     dnf remove -y wget
     dnf clean all
     ;;

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -49,7 +49,7 @@ EOF
 # NOTE: gh CLI must be installed before rapids-install-sccache (uses `gh release download`)
 ARG SCCACHE_VER=notset
 ARG GH_CLI_VER=notset
-RUN <<EOF
+RUN --mount=type=secret,id=GH_TOKEN <<EOF
 case "${LINUX_VER}" in
   "ubuntu"*)
     i=0; until apt-get update -y; do ((++i >= 5)) && break; sleep 10; done
@@ -57,7 +57,7 @@ case "${LINUX_VER}" in
     wget -q https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
     wget -q https://github.com/cli/cli/releases/download/v${GH_CLI_VER}/gh_${GH_CLI_VER}_linux_${CPU_ARCH}.tar.gz
     tar -xf gh_*.tar.gz && mv gh_*/bin/gh /usr/local/bin && rm -rf gh_*
-    SCCACHE_VERSION="${SCCACHE_VER}" rapids-install-sccache
+    GH_TOKEN=$(cat /run/secrets/GH_TOKEN) SCCACHE_VERSION="${SCCACHE_VER}" rapids-install-sccache
     apt-get purge -y wget && apt-get autoremove -y
     rm -rf /var/lib/apt/lists/*
     ;;
@@ -66,7 +66,7 @@ case "${LINUX_VER}" in
     wget -q https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
     wget -q https://github.com/cli/cli/releases/download/v${GH_CLI_VER}/gh_${GH_CLI_VER}_linux_${CPU_ARCH}.tar.gz
     tar -xf gh_*.tar.gz && mv gh_*/bin/gh /usr/local/bin && rm -rf gh_*
-    SCCACHE_VERSION="${SCCACHE_VER}" rapids-install-sccache
+    GH_TOKEN=$(cat /run/secrets/GH_TOKEN) SCCACHE_VERSION="${SCCACHE_VER}" rapids-install-sccache
     dnf remove -y wget
     dnf clean all
     ;;


### PR DESCRIPTION
## Summary
- Pass `GITHUB_TOKEN` as a Docker build secret for `gh` CLI authentication
- Fixes `rapids-install-sccache` failing due to unauthenticated `gh release download`
- Update README with local build instructions