### PR TITLE
Add CUDA 13.1.0 support

### DIFF
--- a/latest.yaml
+++ b/latest.yaml
@@ -2,19 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # Define the values used for the "latest" tag
 miniforge-cuda:
-  CUDA_VER: "13.0.2"
+  CUDA_VER: "13.1.0"
   PYTHON_VER: "3.13"
   LINUX_VER: "ubuntu24.04"
 ci-conda:
-  CUDA_VER: "13.0.2"
+  CUDA_VER: "13.1.0"
   PYTHON_VER: "3.13"
   LINUX_VER: "ubuntu24.04"
 ci-wheel:
-  CUDA_VER: "13.0.2"
+  CUDA_VER: "13.1.0"
   PYTHON_VER: "3.13"
   # Wheels should always be built with the oldest supported glibc version
   LINUX_VER: "rockylinux8"
 citestwheel:
-  CUDA_VER: "13.0.2"
+  CUDA_VER: "13.1.0"
   PYTHON_VER: "3.13"
   LINUX_VER: "ubuntu24.04"

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -4,6 +4,7 @@ CUDA_VER:
   - "12.2.2"
   - "12.9.1"
   - "13.0.2"
+  - "13.1.0"
 PYTHON_VER:
   - "3.10"
   - "3.11"
@@ -33,6 +34,8 @@ exclude:
 
   # Only build ci-wheel for the latest CUDA of each major version
   - CUDA_VER: "12.2.2"
+    IMAGE_REPO: "ci-wheel"
+  - CUDA_VER: "13.0.2"
     IMAGE_REPO: "ci-wheel"
 
   # Only build ci-wheel for the oldest glibc (rockylinux8)


### PR DESCRIPTION
## Summary
- Add CUDA 13.1.0 to the build matrix
- Update latest tags to use CUDA 13.1.0
- Exclude ci-wheel builds for CUDA 13.0.2 (only build wheels for latest CUDA of each major version)

Part of https://github.com/rapidsai/build-planning/issues/236