### PR TITLE
smaller images: remove docs files and build artifacts, consolidate layers

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -284,9 +284,11 @@ esac
 # clear the pip cache, to shrink image size and prevent unintentionally
 # pinning CI to older versions of things
 pip cache purge
-EOF
 
-RUN /opt/conda/bin/git config --system --add safe.directory '*'
+# Allow git to clone anywhere (these are images for isolated, short-lived CI containers,
+# don't need to worry about this setting intended for long-lived / shared servers)
+/opt/conda/bin/git config --system --add safe.directory '*'
+EOF
 
 # Add pip.conf
 COPY pip.conf /etc/xdg/pip/pip.conf

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -59,9 +59,7 @@ SCCACHE_VER=${SCCACHE_VER} \
     --gh-cli \
     --gha-tools \
     --sccache
-EOF
 
-RUN <<EOF
 case "${LINUX_VER}" in
   "ubuntu"*)
     rapids-retry apt-get update -y
@@ -119,24 +117,29 @@ case "${LINUX_VER}" in
     add-apt-repository -r ppa:git-core/ppa
     add-apt-repository -r ppa:ubuntu-toolchain-r/test
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90 --slave /usr/bin/g++ g++ /usr/bin/g++-9 --slave /usr/bin/gcov gcov /usr/bin/gcov-9
-    rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
+    rm -rf \
+      /var/cache/apt/archives \
+      /var/lib/apt/lists/*
     ;;
   "rockylinux"*)
     dnf update -y
-    dnf install -y epel-release
+    dnf install --nodocs -y epel-release
     dnf update -y
     PACKAGES_TO_INSTALL=(
       autoconf
       automake
+      blas-devel
       bzip2
       bzip2-devel
       ca-certificates
       cmake
       curl
       dnf-plugins-core
-      gcc
+      gcc-toolset-14-gcc
+      gcc-toolset-14-gcc-c++
       git
       jq
+      lapack-devel
       libcudnn8-devel
       libcurl-devel
       libffi-devel
@@ -156,6 +159,7 @@ case "${LINUX_VER}" in
       which
       xz
       xz-devel
+      yasm
       zip
       zlib-devel
     )
@@ -168,13 +172,10 @@ case "${LINUX_VER}" in
       echo "libnccl-devel already installed"
     fi
 
-    dnf install -y \
+    dnf install --nodocs -y \
       "${PACKAGES_TO_INSTALL[@]}"
     update-ca-trust extract
     dnf config-manager --set-enabled powertools
-    dnf install -y blas-devel lapack-devel
-    dnf -y install gcc-toolset-14-gcc gcc-toolset-14-gcc-c++
-    dnf -y install yasm
     dnf clean all
     echo -e ' \
       #!/bin/bash\n \
@@ -188,12 +189,19 @@ case "${LINUX_VER}" in
     make
     make install
     popd
+    rm -rf /tmp/openssl*
     ;;
   *)
     echo "Unsupported LINUX_VER: ${LINUX_VER}"
     exit 1
     ;;
 esac
+
+# clean up docs and other unnecessary stuff
+rm -rf \
+  /usr/share/doc \
+  /usr/share/info \
+  /usr/share/man
 EOF
 
 # Set AUDITWHEEL_* env vars for use with auditwheel
@@ -218,9 +226,7 @@ case "${LINUX_VER}" in
     exit 1
     ;;
 esac
-EOF
 
-RUN <<EOF
 pyenv global ${PYTHON_VER}
 # `rapids-pip-retry` defaults to using `python -m pip` to select which `pip` to
 # use so should be compatible with `pyenv`
@@ -244,14 +250,12 @@ rapids-pip-retry install \
   "${PACKAGES_TO_INSTALL[@]}"
 pip cache purge
 pyenv rehash
-EOF
 
-RUN <<EOF
 # Create output directory for wheel builds
 mkdir -p ${RAPIDS_WHEEL_BLD_OUTPUT_DIR}
 
-# Mark all directories as safe for git so that GHA clones into the root don't
-# run into issues
+# Allow git to clone anywhere (these are images for isolated, short-lived CI containers,
+# don't need to worry about this setting intended for long-lived / shared servers)
 git config --system --add safe.directory '*'
 EOF
 

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -124,6 +124,7 @@ case "${LINUX_VER}" in
   "rockylinux"*)
     dnf update -y
     dnf install --nodocs -y epel-release
+    dnf config-manager --set-enabled powertools
     dnf update -y
     PACKAGES_TO_INSTALL=(
       autoconf
@@ -175,7 +176,6 @@ case "${LINUX_VER}" in
     dnf install --nodocs -y \
       "${PACKAGES_TO_INSTALL[@]}"
     update-ca-trust extract
-    dnf config-manager --set-enabled powertools
     dnf clean all
     echo -e ' \
       #!/bin/bash\n \

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -48,9 +48,7 @@ REAL_ARCH=${REAL_ARCH} \
     --aws-cli \
     --gh-cli \
     --gha-tools
-EOF
 
-RUN <<EOF
 set -e
 case "${LINUX_VER}" in
   "ubuntu"*)
@@ -170,10 +168,11 @@ rapids-pip-retry install \
   'certifi>=2026.1.4' \
   'rapids-dependency-file-generator==1.*'
 pyenv rehash
-EOF
 
-# git safe directory
-RUN git config --system --add safe.directory '*'
+# Allow git to clone anywhere (these are images for isolated, short-lived CI containers,
+# don't need to worry about this setting intended for long-lived / shared servers)
+git config --system --add safe.directory '*'
+EOF
 
 # Add pip.conf
 COPY pip.conf /etc/xdg/pip/pip.conf

--- a/context/scripts/install-tools
+++ b/context/scripts/install-tools
@@ -121,6 +121,7 @@ if [[ "${#PACKAGES_TO_INSTALL[@]}" != "0" ]]; then
         apt-get purge -y \
           "${PACKAGE_TO_INSTALL[@]}"
         apt-get autoremove -y
+        rm -rf \
           /var/cache/apt/archives \
           /var/lib/apt/lists/*
     else

--- a/context/scripts/install-tools
+++ b/context/scripts/install-tools
@@ -66,7 +66,7 @@ if [[ "${#PACKAGES_TO_INSTALL[@]}" != "0" ]]; then
         "${PACKAGES_TO_INSTALL[@]}"
   else
       dnf update -y
-      dnf install -y \
+      dnf install --nodocs -y \
         "${PACKAGES_TO_INSTALL[@]}"
   fi
 fi
@@ -121,10 +121,16 @@ if [[ "${#PACKAGES_TO_INSTALL[@]}" != "0" ]]; then
         apt-get purge -y \
           "${PACKAGE_TO_INSTALL[@]}"
         apt-get autoremove -y
-        rm -rf /var/lib/apt/lists/*
+          /var/cache/apt/archives \
+          /var/lib/apt/lists/*
     else
         dnf remove -y \
           "${PACKAGES_TO_INSTALL[@]}"
         dnf clean all
     fi
+    # either way, clean up docs and other unnecessary stuff
+    rm -rf \
+      /usr/share/doc \
+      /usr/share/info \
+      /usr/share/man
 fi


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/shared-workflows/issues/505

A couple of small changes aimed at reducing image sizes (and therefore pull times in CI):

* consolidates some `RUN` steps (fewer layers = smaller image)
* removes `man` pages and other docs
  - adds `--nodocs` to every `dnf install`
  - manually removes `/usr/share/man` and similar
* consolidates some package-install calls *(fewer solves = faster builds)*
* changes specific to rockylinux8 `ci-wheel` images:
  - removes 450+ MB (uncompressed) of left-behind OpenSSL build artifacts in `/tmp`
  - removes `gcc` install *(we're already installing `gcc-toolset-*` packages)*

## Notes for reviewers

### Impact of these changes

For CUDA 12.9.1, Python 3.11, x86_64, rockylinux8:

| image   | before                            | after                            |
|:-----------:|:-------------------------------:|:-----------------------------:|
|ci-conda |  750.78 MB ([link][1])  | 748.72 MB ([link][2]) |
|ci-wheel |   5.24 GB ([link][3])       | 5.14 GB ([link][4])     | 

So not a huge change, but 100MB compressed cut out of `ci-wheel` is decent! Let's merge this and see if pull times improve.

[1]: https://hub.docker.com/layers/rapidsai/ci-conda/26.04-cuda12.9.1-rockylinux8-py3.11/images/sha256-0d5f5950ae876c1caed1a02ae9f39e4c69cab6e48fc8f516d95186a9e44fdc05
[2]: https://hub.docker.com/layers/rapidsai/staging/ci-conda-368-26.04-cuda12.9.1-rockylinux8-py3.11-amd64/images/sha256-b5eff8e747224b5e05a38202dcd3fe9a9d3252132c89048257699dc1cdfcbaea
[3]: https://hub.docker.com/layers/rapidsai/ci-wheel/26.04-cuda12.9.1-rockylinux8-py3.11/images/sha256-8b9b085b09651885e61986e4a4ce9c5a341454a9bb0c45afd6f64fbe5d992db1
[4]: https://hub.docker.com/layers/rapidsai/staging/ci-wheel-368-26.04-cuda12.9.1-rockylinux8-py3.11-amd64/images/sha256-eadee091ec85881e2e3f4659116d346f8aaf5cf0712bfcdc1bb6699bc10ffe9b
