### PR TITLE
Update latest.yaml CUDA and Python versions to match matrix.yaml

### DIFF
--- a/latest.yaml
+++ b/latest.yaml
@@ -2,15 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Define the values used for the "latest" tag
 ci-conda:
-  CUDA_VER: "13.1.0"
-  PYTHON_VER: "3.13"
+  CUDA_VER: "13.1.1"
+  PYTHON_VER: "3.14"
   LINUX_VER: "ubuntu24.04"
 ci-wheel:
-  CUDA_VER: "13.1.0"
-  PYTHON_VER: "3.13"
+  CUDA_VER: "13.1.1"
+  PYTHON_VER: "3.14"
   # Wheels should always be built with the oldest supported glibc version
   LINUX_VER: "rockylinux8"
 citestwheel:
-  CUDA_VER: "13.1.0"
-  PYTHON_VER: "3.13"
+  CUDA_VER: "13.1.1"
+  PYTHON_VER: "3.14"
   LINUX_VER: "ubuntu24.04"

--- a/latest.yaml
+++ b/latest.yaml
@@ -3,14 +3,14 @@
 # Define the values used for the "latest" tag
 ci-conda:
   CUDA_VER: "13.1.1"
-  PYTHON_VER: "3.14"
+  PYTHON_VER: "3.13"
   LINUX_VER: "ubuntu24.04"
 ci-wheel:
   CUDA_VER: "13.1.1"
-  PYTHON_VER: "3.14"
+  PYTHON_VER: "3.13"
   # Wheels should always be built with the oldest supported glibc version
   LINUX_VER: "rockylinux8"
 citestwheel:
   CUDA_VER: "13.1.1"
-  PYTHON_VER: "3.14"
+  PYTHON_VER: "3.13"
   LINUX_VER: "ubuntu24.04"


### PR DESCRIPTION
Updates `latest.yaml` to use the greatest CUDA and Python versions from `matrix.yaml`:

- CUDA: `13.1.0` -> `13.1.1`
- Python: `3.13` -> `3.14`

The `-latest` CI image tag is built from the CUDA/Python combo specified in `latest.yaml`. When `matrix.yaml` was updated with new CUDA and Python versions, `latest.yaml` wasn't updated to match, so the `-latest` tag could no longer be published. This broke shared-workflows `@main` which references the `-latest` images.