### PR TITLE
feat: set Python 3.14 as latest version

### DIFF
--- a/latest.yaml
+++ b/latest.yaml
@@ -3,14 +3,14 @@
 # Define the values used for the "latest" tag
 ci-conda:
   CUDA_VER: "13.1.0"
-  PYTHON_VER: "3.13"
+  PYTHON_VER: "3.14"
   LINUX_VER: "ubuntu24.04"
 ci-wheel:
   CUDA_VER: "13.1.0"
-  PYTHON_VER: "3.13"
+  PYTHON_VER: "3.14"
   # Wheels should always be built with the oldest supported glibc version
   LINUX_VER: "rockylinux8"
 citestwheel:
   CUDA_VER: "13.1.0"
-  PYTHON_VER: "3.13"
+  PYTHON_VER: "3.14"
   LINUX_VER: "ubuntu24.04"


### PR DESCRIPTION
Part of rapidsai/build-planning#205

Adding a `DO NOT MERGE` tag here so @jameslamb can sign off and confirm this won't mess up his work fixing the dependencies in `cugraph-gnn`