### PR TITLE
Forward-merge release/26.04 into main

### DIFF
--- a/latest.yaml
+++ b/latest.yaml
@@ -3,14 +3,14 @@
 # Define the values used for the "latest" tag
 ci-conda:
   CUDA_VER: "13.1.0"
-  PYTHON_VER: "3.13"
+  PYTHON_VER: "3.14"
   LINUX_VER: "ubuntu24.04"
 ci-wheel:
   CUDA_VER: "13.1.0"
-  PYTHON_VER: "3.13"
+  PYTHON_VER: "3.14"
   # Wheels should always be built with the oldest supported glibc version
   LINUX_VER: "rockylinux8"
 citestwheel:
   CUDA_VER: "13.1.0"
-  PYTHON_VER: "3.13"
+  PYTHON_VER: "3.14"
   LINUX_VER: "ubuntu24.04"


### PR DESCRIPTION
Fixing the forward merge from #383 into `main`

Note to self to remember to `/merge nosquash` after approval

Authors:
  - Gil Forsyth (https://github.com/gforsyth)

Approvers:
  - James Lamb (https://github.com/jameslamb)

URL: https://github.com/rapidsai/ci-imgs/pull/383