### PR TITLE
ci-wheel: drop CUDA 12.2.2 images, move latest back to 13.0.2

### DIFF
--- a/latest.yaml
+++ b/latest.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # Define the values used for the "latest" tag
 ci-conda:
@@ -6,7 +6,7 @@ ci-conda:
   PYTHON_VER: "3.14"
   LINUX_VER: "ubuntu24.04"
 ci-wheel:
-  CUDA_VER: "13.1.0"
+  CUDA_VER: "13.0.2"
   PYTHON_VER: "3.14"
   # Wheels should always be built with the oldest supported glibc version
   LINUX_VER: "rockylinux8"

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -30,6 +30,11 @@ exclude:
   - LINUX_VER: "ubuntu24.04"
     CUDA_VER: "12.2.2"
 
+  # Only build ci-wheel for the latest CUDA of each major version,
+  # and any others used for builds in CI
+  - CUDA_VER: "12.2.2"
+    IMAGE_REPO: "ci-wheel"
+
   # Only build ci-wheel for the oldest glibc (rockylinux8)
   - LINUX_VER: "ubuntu22.04"
     IMAGE_REPO: "ci-wheel"


### PR DESCRIPTION
Fixes #374

#373 added CUDA 13.0.2 and 12.2.2 `ci-wheel` images, for use in experimenting with building RAPIDS against older CTKs. The 13.0.2 images must be kept for now (https://github.com/rapidsai/build-planning/issues/257), but the 12.2.2 images aren't needed.

This:

* excludes `ci-wheel` CUDA 12.2.2 images
* moves `ci-wheel:{rapids-version}-latest` to CUDA 13.0.2, to align with how we're building wheels as of https://github.com/rapidsai/build-planning/issues/257
  - _NOTE: only really matters in CI for the next time we got to build `libucx` wheels (ref: https://github.com/rapidsai/shared-workflows/pull/510#pullrequestreview-3967966570), but still helpful for quick local debugging / CI reproductions_