### PR TITLE
renovate: group all GitHub Actions updates together

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,13 @@
   ],
   "packageRules": [
     {
+      "description": "Update GitHub Actions together",
+      "groupName": "github-actions",
+      "matchManagers": [
+        "github-actions"
+      ]
+    },
+    {
       "description": "Update low-risk CLI tools together",
       "groupName": "cli-tools",
       "matchPackageNames": [


### PR DESCRIPTION
It's the first of the month, so `renovate` updates are coming in. I noticed 3 separate PRs for GitHub Actions:

* #392 
* #391 
* #390 

This proposes modifying `renovate` configuration so updates for all GitHub Actions will be suggested together in 1 PR. These updates are almost always merged without much controversy or additional changes needed, so I think we should do this to reduce the total amount of CI usages and review churn.

The grouped PRs will look similar to #389