### PR TITLE
smaller images: clean caches, delete unnecessary pyenv stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,13 @@ export CUDA_VER=13.1.0
 export PYTHON_VER=3.13
 export ARCH=amd64
 export GH_TOKEN=$(gh auth token)
+
 export IMAGE_REPO=ci-conda
 docker build $(ci/compute-build-args.sh) --secret id=GH_TOKEN -f ci-conda.Dockerfile context/
+
 export IMAGE_REPO=ci-wheel
 docker build $(ci/compute-build-args.sh) --secret id=GH_TOKEN -f ci-wheel.Dockerfile context/
+
 export IMAGE_REPO=citestwheel
 docker build $(ci/compute-build-args.sh) -f citestwheel.Dockerfile context/
 ```

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -17,7 +17,7 @@ RUN \
 # Ensure new files/dirs have group write permissions
 umask 002
 
-# install gha-tools for rapids-mamba-retry
+# install gha-tools for rapids-conda-retry
 /tmp/build-scripts/install-tools \
   --gha-tools
 
@@ -30,7 +30,10 @@ umask 002
 # NOTE: 'PATH' is set locally here (instead of 'ENV') because this target is just an intermediate
 #       build that files are copied out of.
 PATH="/opt/conda/bin:$PATH" \
-  rapids-mamba-retry update --all -y -n base
+  rapids-conda-retry update --all -y -n base
+
+PATH="/opt/conda/bin:$PATH" \
+  conda clean -aiptfy
 EOF
 
 FROM nvidia/cuda:${CUDA_VER}-base-${LINUX_VER} AS ci-conda
@@ -107,8 +110,8 @@ if [[ "$PYTHON_VERSION_PADDED" > "3.12" ]]; then
 else
     PYTHON_ABI_TAG="cpython"
 fi
-rapids-mamba-retry install -y -n base "python>=${PYTHON_VERSION},<${PYTHON_UPPER_BOUND}=*_${PYTHON_ABI_TAG}"
-rapids-mamba-retry update --all -y -n base
+rapids-conda-retry install -y -n base "python>=${PYTHON_VERSION},<${PYTHON_UPPER_BOUND}=*_${PYTHON_ABI_TAG}"
+rapids-conda-retry update --all -y -n base
 if [[ "$LINUX_VER" == "rockylinux"* ]]; then
   dnf install -y findutils
   dnf clean all
@@ -192,10 +195,10 @@ ENV RAPIDS_CONDA_BLD_ROOT_DIR=/tmp/conda-bld-workspace
 ENV RAPIDS_CONDA_BLD_OUTPUT_DIR=/tmp/conda-bld-output
 COPY condarc.tmpl /tmp/condarc.tmpl
 
-# Install CI tools using mamba
+# Install CI tools using conda
 RUN <<EOF
 # Install prereq for envsubst
-rapids-mamba-retry install -y \
+rapids-conda-retry install -y \
   gettext
 
 # create condarc file from env vars
@@ -229,7 +232,7 @@ PACKAGES_TO_INSTALL=(
   'rattler-build>=0.55.0,<0.58'
 )
 
-rapids-mamba-retry install -y \
+rapids-conda-retry install -y \
   "${PACKAGES_TO_INSTALL[@]}"
 
 conda clean -aiptfy

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -25,6 +25,9 @@ ENV PATH="${PYENV_ROOT}/bin:${PYENV_ROOT}/shims:$PATH"
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+# Add pip.conf
+COPY pip.conf /etc/xdg/pip/pip.conf
+
 # Install all the tools that are just "download a binary and stick it on PATH".
 #
 # These can be together, and earlier, because they're very cache-friendly... the versions are
@@ -248,8 +251,14 @@ PACKAGES_TO_INSTALL=(
 )
 rapids-pip-retry install \
   "${PACKAGES_TO_INSTALL[@]}"
-pip cache purge
+
 pyenv rehash
+
+# clear the pip cache
+pip cache purge
+
+# remove unnecessary pyenv stuff
+/tmp/build-scripts/clean-pyenv
 
 # Create output directory for wheel builds
 mkdir -p ${RAPIDS_WHEEL_BLD_OUTPUT_DIR}
@@ -258,8 +267,5 @@ mkdir -p ${RAPIDS_WHEEL_BLD_OUTPUT_DIR}
 # don't need to worry about this setting intended for long-lived / shared servers)
 git config --system --add safe.directory '*'
 EOF
-
-# Add pip.conf
-COPY pip.conf /etc/xdg/pip/pip.conf
 
 CMD ["/bin/bash"]

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -212,7 +212,9 @@ ARG MANYLINUX_VER=notset
 ARG POLICY=${MANYLINUX_VER}
 ENV AUDITWHEEL_POLICY=${POLICY} AUDITWHEEL_ARCH=${REAL_ARCH} AUDITWHEEL_PLAT=${POLICY}_${REAL_ARCH}
 
-RUN <<EOF
+RUN \
+  --mount=type=bind,source=scripts,target=/tmp/build-scripts \
+<<EOF
 # install pyenv
 rapids-retry curl https://pyenv.run | bash
 

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -18,6 +18,9 @@ ENV RAPIDS_CONDA_ARCH="${CONDA_ARCH}"
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+# Add pip.conf
+COPY pip.conf /etc/xdg/pip/pip.conf
+
 # Install all the tools that are just "download a binary and stick it on PATH".
 #
 # These can be together, and earlier, because they're very cache-friendly... the versions are
@@ -151,8 +154,10 @@ EOF
 ENV PYENV_ROOT="/pyenv"
 ENV PATH="${PYENV_ROOT}/versions/${PYTHON_VER}/bin/:${PYENV_ROOT}/bin:${PYENV_ROOT}/shims:$PATH"
 
-# Create pyenvs
-RUN <<EOF
+# Set up requested Python version
+RUN \
+  --mount=type=bind,source=scripts,target=/tmp/build-scripts \
+<<EOF
 # install pyenv
 rapids-retry curl https://pyenv.run | bash
 
@@ -167,14 +172,18 @@ rapids-pip-retry install --upgrade pip
 rapids-pip-retry install \
   'certifi>=2026.1.4' \
   'rapids-dependency-file-generator==1.*'
+
 pyenv rehash
+
+# clear the pip cache
+pip cache purge
+
+# remove unnecessary pyenv stuff
+/tmp/build-scripts/clean-pyenv
 
 # Allow git to clone anywhere (these are images for isolated, short-lived CI containers,
 # don't need to worry about this setting intended for long-lived / shared servers)
 git config --system --add safe.directory '*'
 EOF
-
-# Add pip.conf
-COPY pip.conf /etc/xdg/pip/pip.conf
 
 CMD ["/bin/bash"]

--- a/context/.dockerignore
+++ b/context/.dockerignore
@@ -1,6 +1,7 @@
 # reduce the risk of other files accidentally included in context/ getting passed to image builds
 *
 !condarc.tmpl
+!scripts/clean-pyenv
 !scripts/configure-apt
 !scripts/install-tools
 !pip.conf

--- a/context/scripts/clean-pyenv
+++ b/context/scripts/clean-pyenv
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
+# started - 377M
+
+# delete logs from 'pyenv install'
+rm -rf /tmp/python-build*.log
+
+# delete git and GitHub stuff
+find "${PYENV_ROOT}" -type d -name '.git' -exec rm -rf '{}' \+
+find "${PYENV_ROOT}" -type d -name '.github' -exec rm -rf '{}' \+
+
+# delete docs
+find "${PYENV_ROOT}" -type d -name 'man' -exec rm -rf '{}' \+
+
+# delete tests
+find "${PYENV_ROOT}" -type d -name 'test' -exec rm -rf '{}' \+
+
+# delete plugins
+#
+# These are only needed at image-building time, e.g. 'plugins/python-build' is needed for 'pyenv install'.
+#
+# The only direct 'pyenv' invocation in RAPIDS CI at runtime is 'pyenv rehash', which doesn't need any plugins.
+rm -rf "${PYENV_ROOT}/plugins"

--- a/context/scripts/clean-pyenv
+++ b/context/scripts/clean-pyenv
@@ -2,8 +2,6 @@
 
 set -e -u -o pipefail
 
-# started - 377M
-
 # delete logs from 'pyenv install'
 rm -rf /tmp/python-build*.log
 


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/shared-workflows/issues/505

* more aggressively cleans `conda` caches
* removes unnecessary `/pyenv` files
* moves a `COPY` statement earlier in the Dockerfiles
  - *slow-changing things should generally be earlier, to help with caching*
* switches remaining `mamba` uses to `conda` (similar to https://github.com/rapidsai/docker/pull/858)

## Notes for Reviewers

### Size Impact

Checked the compressed sizes of `26.06-cuda13.2.0-rockylinux8-py3.14-amd64` images for all 3 images.

| image           | latest         | this PR      |
|:-----------------:|:---------------:|:-------------:|
|`ci-conda`      |   913 MB    |   651 MB  |
|`ci-wheel`       | 4440 MB   | 4420 MB  |
|`citestwheel` | 3270 MB    | 3250 MB |

So ok, not a ton, but still an improvement!