### PR TITLE
fix: update `pip.conf` location to work around pip config bug

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -295,6 +295,6 @@ pip cache purge
 EOF
 
 # Add pip.conf
-COPY pip.conf /etc/xdg/pip/pip.conf
+COPY pip.conf /etc/pip.conf
 
 CMD ["/bin/bash"]

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -26,7 +26,7 @@ ENV PATH="${PYENV_ROOT}/bin:${PYENV_ROOT}/shims:$PATH"
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # Add pip.conf
-COPY pip.conf /etc/xdg/pip/pip.conf
+COPY pip.conf /etc/pip.conf
 
 # Install all the tools that are just "download a binary and stick it on PATH".
 #

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -19,7 +19,7 @@ ENV RAPIDS_CONDA_ARCH="${CONDA_ARCH}"
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # Add pip.conf
-COPY pip.conf /etc/xdg/pip/pip.conf
+COPY pip.conf /etc/pip.conf
 
 # Install all the tools that are just "download a binary and stick it on PATH".
 #


### PR DESCRIPTION
Resolves #398 -- the two locations _should_ be interchangeable, but they aren't quite, and this location allows us to use `pip config set` and `pip config unset` for plucking out keys we want to selectively remove.
