### PR TITLE
refactor(citestwheel): switch base image from devel to base

### DIFF
--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -114,12 +114,14 @@ case "${LINUX_VER}" in
       ca-certificates
       curl
       dnf-plugins-core
+      findutils
       gcc
       git
       jq
       libffi-devel
-      patch
+      make
       ncurses-devel
+      patch
       readline-devel
       sqlite
       sqlite-devel

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -3,7 +3,7 @@
 
 ARG CUDA_VER=notset
 ARG LINUX_VER=notset
-FROM nvidia/cuda:${CUDA_VER}-devel-${LINUX_VER}
+FROM nvidia/cuda:${CUDA_VER}-base-${LINUX_VER}
 
 ARG CONDA_ARCH=notset
 ARG CUDA_VER=notset


### PR DESCRIPTION
Building `citestwheel` using the `base` version of the upstream `cuda` image.

Opening this PR so that the image gets built and pushed to staging - I'll work on testing this out on a few repos before merging.