### PR TITLE
bump to sccache v0.14.0-rapids.12

### DIFF
--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -56,9 +56,9 @@ set -e
 case "${LINUX_VER}" in
   "ubuntu"*)
     rapids-retry apt-get update -y
-    apt-get install -y software-properties-common
-    # update git > 2.17
-    add-apt-repository ppa:git-core/ppa -y
+    # apt-get install -y software-properties-common
+    # # update git > 2.17
+    # add-apt-repository ppa:git-core/ppa -y
     rapids-retry apt-get update -y
     apt-get upgrade -y
 

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -56,9 +56,6 @@ set -e
 case "${LINUX_VER}" in
   "ubuntu"*)
     rapids-retry apt-get update -y
-    # apt-get install -y software-properties-common
-    # # update git > 2.17
-    # add-apt-repository ppa:git-core/ppa -y
     rapids-retry apt-get update -y
     apt-get upgrade -y
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -11,4 +11,4 @@ AWS_CLI_VER: 2.28.1
 # renovate: datasource=docker depName=condaforge/miniforge3 versioning=docker
 MINIFORGE_VER: 25.11.0-0
 # renovate: datasource=github-releases depName=rapidsai/sccache
-SCCACHE_VER: 0.14.0-rapids.3
+SCCACHE_VER: 0.14.0-rapids.12


### PR DESCRIPTION
Due to the ongoing Canonical attack, I commented out the `add-apt-repository ppa:git-core/ppa` line in `citestwheel.Dockerfile`. The comment says it's so we install git > v2.17, but Ubuntu 22.04 seems to be our min version, and that has git v2.34.1.