### PR TITLE
fix: swap version update/downgrade and general update

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -110,8 +110,8 @@ if [[ "$PYTHON_VERSION_PADDED" > "3.12" ]]; then
 else
     PYTHON_ABI_TAG="cpython"
 fi
-rapids-conda-retry install -y -n base "python>=${PYTHON_VERSION},<${PYTHON_UPPER_BOUND}=*_${PYTHON_ABI_TAG}"
 rapids-conda-retry update --all -y -n base
+rapids-conda-retry install -y -n base "python>=${PYTHON_VERSION},<${PYTHON_UPPER_BOUND}=*_${PYTHON_ABI_TAG}"
 if [[ "$LINUX_VER" == "rockylinux"* ]]; then
   dnf install -y findutils
   dnf clean all

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -99,6 +99,11 @@ chmod g+ws /opt/conda
 # Ensure new files/dirs have group write permissions
 umask 002
 
+# force-reinstall 'conda' first, to clear out any files
+# left behind from updates
+rapids-conda-retry install -y -n base --force-reinstall 'conda>=26.5.0'
+
+
 # install expected Python version
 PYTHON_MAJOR_VERSION=${PYTHON_VERSION%%.*}
 PYTHON_MINOR_VERSION=${PYTHON_VERSION#*.}
@@ -110,8 +115,12 @@ if [[ "$PYTHON_VERSION_PADDED" > "3.12" ]]; then
 else
     PYTHON_ABI_TAG="cpython"
 fi
-rapids-conda-retry update --all -y -n base
+
 rapids-conda-retry install -y -n base "python>=${PYTHON_VERSION},<${PYTHON_UPPER_BOUND}=*_${PYTHON_ABI_TAG}"
+
+# ensure all packages are updated
+rapids-conda-retry update --all -y -n base
+
 if [[ "$LINUX_VER" == "rockylinux"* ]]; then
   dnf install -y findutils
   dnf clean all


### PR DESCRIPTION
Debugging failures that showed up in https://github.com/rapidsai/ci-imgs/actions/runs/26057524971/job/76609236506?pr=408#step:9:6848 while working on #408 

@jameslamb is seeing the same thing over in `rapidsai/docker` (tracked at https://github.com/rapidsai/docker/issues/878)
 
**update 2026-05-19**

@jameslamb figured out that force-reinstalling `conda` before performing any other `conda` operations fixes the notices loading issue.
I've applied those same changed here and reverted the previous change.
