### PR TITLE
WIP: opt out of sharded repodata

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -294,6 +294,12 @@ pip cache purge
 /opt/conda/bin/git config --system --add safe.directory '*'
 EOF
 
+# opt out of conda sharded repodata
+#
+# TODO: remove these when https://github.com/conda/infrastructure/issues/1286#issuecomment-4628580232 is resolved
+ENV CONDA_PLUGINS_USE_SHARDED_REPODATA=false
+ENV RATTLER_SHARDED=false
+
 # Add pip.conf
 COPY pip.conf /etc/pip.conf
 


### PR DESCRIPTION
Sharded repodata was enabled on the `rapidsai` channel in mid-April: https://github.com/rapidsai/build-planning/issues/240#issuecomment-4247344676

During the 26.06 release, we found that sharded repodata updates were not propagating through anaconda.org's CDN, blocking CI with "package not found" types of issues: https://github.com/rapidsai/cugraph/pull/5542#discussion_r3360573913

This proposes opting out of sharded repodata for the 26.06 release. Hopefully it can be reverted on `main` when those issues are resolved. 