### PR TITLE
Add zstd support for pyenv Python builds

### DIFF
--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -90,6 +90,7 @@ case "${LINUX_VER}" in
       libsqlite3-dev
       libssl-dev
       libtool
+      libzstd-dev
       openssh-client
       patch
       protobuf-compiler
@@ -193,6 +194,19 @@ case "${LINUX_VER}" in
     make install
     popd
     rm -rf /tmp/openssl*
+    # Python 3.14 adds stdlib compression.zstd and requires libzstd >=1.4.5.
+    # Rocky 8 packages libzstd 1.4.4, so provide a newer zstd before pyenv
+    # builds Python. See https://github.com/pyenv/pyenv/wiki.
+    ZSTD_VERSION=1.5.7
+    pushd /tmp
+    rapids-retry wget -q "https://github.com/facebook/zstd/releases/download/v${ZSTD_VERSION}/zstd-${ZSTD_VERSION}.tar.gz"
+    tar -xzvf "zstd-${ZSTD_VERSION}.tar.gz"
+    cd "zstd-${ZSTD_VERSION}"
+    make -j"$(nproc)" lib-release
+    make -C lib install PREFIX=/usr LIBDIR=/usr/lib64
+    ldconfig
+    popd
+    rm -rf /tmp/zstd*
     ;;
   *)
     echo "Unsupported LINUX_VER: ${LINUX_VER}"

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -75,6 +75,7 @@ case "${LINUX_VER}" in
       libssl-dev
       libxml2-dev
       libxmlsec1-dev
+      libzstd-dev
       llvm
       make
       patch
@@ -115,8 +116,8 @@ case "${LINUX_VER}" in
       git
       jq
       libffi-devel
-      patch
       ncurses-devel
+      patch
       readline-devel
       sqlite
       sqlite-devel
@@ -140,6 +141,20 @@ case "${LINUX_VER}" in
     make
     make install
     popd
+    rm -rf /tmp/openssl*
+    # Python 3.14 adds stdlib compression.zstd and requires libzstd >=1.4.5.
+    # Rocky 8 packages libzstd 1.4.4, so provide a newer zstd before pyenv
+    # builds Python. See https://github.com/pyenv/pyenv/wiki.
+    ZSTD_VERSION=1.5.7
+    pushd /tmp
+    rapids-retry wget -q "https://github.com/facebook/zstd/releases/download/v${ZSTD_VERSION}/zstd-${ZSTD_VERSION}.tar.gz"
+    tar -xzvf "zstd-${ZSTD_VERSION}.tar.gz"
+    cd "zstd-${ZSTD_VERSION}"
+    make -j"$(nproc)" lib-release
+    make -C lib install PREFIX=/usr LIBDIR=/usr/lib64
+    ldconfig
+    popd
+    rm -rf /tmp/zstd*
     ;;
   *)
     echo "Unsupported LINUX_VER: ${LINUX_VER}"


### PR DESCRIPTION
## Summary
- install zstd development headers for Ubuntu pyenv-based images
- build zstd 1.5.7 from source on Rocky, where the distro package is too old for Python 3.14 stdlib zstd support
- apply the same support to both ci-wheel and citestwheel pyenv image families

## Context
conda-package-handling 2.5.0 / conda-package-streaming 0.13.0 expects Python 3.14 to provide compression.zstd or to have backports.zstd installed. The current pyenv-built Python 3.14 in the wheel image lacks _zstd, and backports.zstd is not available for Python 3.14, so unpacking .conda artifacts fails before CI checks run.

## Local validation
- built ci-wheel:zstd-py314-rocky with Python 3.14 on Rocky Linux 8
- verified import compression.zstd succeeds in that image
- verified conda-package-handling 2.5.0 / conda-package-streaming 0.13.0 use compression.zstd as the streaming backend
- built citestwheel:zstd-py314-ubuntu with Python 3.14 on Ubuntu 24.04
- verified import compression.zstd succeeds in that image