### PR TITLE
ci-wheel: use GCC toolset when building CPython and its dependencies

### DIFF
--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -237,7 +237,16 @@ case "${LINUX_VER}" in
     pyenv install --verbose "${RAPIDS_PY_VERSION}"
     ;;
   "rockylinux"*)
-    # Need to specify the openssl location because of the install from source
+    # Activate gcc-toolset so its toolchain is used when building CPython and other libraries
+    # from source below.
+    #
+    # In some situations, CPython's ./configure may record an absolute path for
+    # the compiler. Not ideal, but if that's going to happen we want it to be the one
+    # used for building RAPIDS packages, because scikit-build-core retries that value
+    # with `sysconfig.get_config_var("CXX")`.
+    source /etc/profile.d/enable_devtools.sh
+
+    # Need to specify the openssl location because of the install from source.
     CPPFLAGS="-I/usr/include/openssl" LDFLAGS="-L/usr/lib" pyenv install --verbose "${RAPIDS_PY_VERSION}"
     ;;
   *)


### PR DESCRIPTION
Contributes to #420 (hopefully "fixes", but we'll see 😅)

As described there, we observed wheel builds using `scikit-build-core` falling back to the GCC 8.5 at `/usr/bin/g++`.

```text
  -- The CXX compiler identification is GNU 8.5.0
  -- The CUDA compiler identification is NVIDIA 12.9.86 with host compiler GNU 14.2.1
  -- Detecting CXX compiler ABI info
  -- Detecting CXX compiler ABI info - done
  -- Check for working CXX compiler: /usr/bin/g++ - skipped
```

Despite enabling the GCC 14 toolset:

https://github.com/rapidsai/ci-imgs/blob/2bbcab77116642b15f764df2b33fe3ff1bd57b90/ci-wheel.Dockerfile#L143-L144

It looks like the root cause is something like:

* `sysconfig.get_config_var("CXX")` returns the compiler the Python interpreter was built with
* at some point recently (possibly https://github.com/python/cpython/pull/148298), CPython started recording an absolute path like `/usr/bin/g++`
* we build CPython from source in the `ci-wheel` images used in RAPIDS, `/usr/bin/g++` is the first C++ compiler on `PATH` at the time that build happens
* `scikit-build-core` reads that value when configuring CMake projects ([scikit-build/scikit-build-core - src/scikit_build_Core/builder/generator.py](https://github.com/scikit-build/scikit-build-core/blob/05948f43ffa21f5ab84c0c2d239f1509d5e39882/src/scikit_build_core/builder/generator.py#L118))
* activating the GCC toolset doesn't work because that absolute path circumvents any `PATH` lookup at CMake configure time... `/usr/bin/g++` is used unconditionally

This attempts to fix it by activating the GCC toolset before building CPython.

## Notes for Reviewers

I haven't tested this locally, getting the PR up to start CI before I have to step away for a bit. Will try to return to it tonight.

I also think I have an idea of which CPython change caused this, will report an issue upstream tonight.