### PR TITLE
speed up wheel image builds

### DIFF
--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -189,8 +189,12 @@ case "${LINUX_VER}" in
         tar -xzvf openssl-1.1.1k.tar.gz
     cd openssl-1.1.1k
     ./config --prefix=/usr --openssldir=/etc/ssl --libdir=lib no-shared zlib-dynamic
-    make
-    make install
+    # 'install_sw' installs just the libraries, headers, and binaries.
+    # Plain 'install' also (slowly) generates and installs the HTML manpages, which we don't need.
+    #
+    # ref: https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/INSTALL
+    #
+    make -j"$(nproc)" install_sw
     popd
     rm -rf /tmp/openssl*
     ;;
@@ -217,6 +221,10 @@ RUN \
 <<EOF
 # install pyenv
 rapids-retry curl https://pyenv.run | bash
+
+# Skip building CPython's own test modules. RAPIDS CI builds and tests wheels,
+# not CPython itself, so these just slow down the build.
+export PYTHON_CONFIGURE_OPTS="--disable-test-modules"
 
 case "${LINUX_VER}" in
   "ubuntu"*)

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -195,7 +195,8 @@ case "${LINUX_VER}" in
     #
     # ref: https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/INSTALL
     #
-    make -j"$(nproc)" install_sw
+    make -j"$(nproc)"
+    make install_sw
     popd
     rm -rf /tmp/openssl*
     # Python 3.14 adds stdlib compression.zstd and requires libzstd >=1.4.5.
@@ -235,6 +236,11 @@ RUN \
 <<EOF
 # install pyenv
 rapids-retry curl https://pyenv.run | bash
+
+# explicitly parallelize builds run by pyenv's 'python-build' plugin.
+#
+# ref: https://github.com/pyenv/pyenv/blob/b52a8e3f52c3be68cf46c751ed40a180dfc48ba4/plugins/python-build/README.md?plain=1#L190
+export MAKE_OPTS="-j$(nproc)"
 
 # Skip building CPython's own test modules. RAPIDS CI builds and tests wheels,
 # not CPython itself, so these just slow down the build.

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -142,7 +142,8 @@ case "${LINUX_VER}" in
     #
     # ref: https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/INSTALL
     #
-    make -j"$(nproc)" install_sw
+    make -j"$(nproc)"
+    make install_sw
     popd
     rm -rf /tmp/openssl*
     # Python 3.14 adds stdlib compression.zstd and requires libzstd >=1.4.5.
@@ -175,6 +176,11 @@ RUN \
 <<EOF
 # install pyenv
 rapids-retry curl https://pyenv.run | bash
+
+# explicitly parallelize builds run by pyenv's 'python-build' plugin.
+#
+# ref: https://github.com/pyenv/pyenv/blob/b52a8e3f52c3be68cf46c751ed40a180dfc48ba4/plugins/python-build/README.md?plain=1#L190
+export MAKE_OPTS="-j$(nproc)"
 
 # Skip building CPython's own test modules. RAPIDS CI builds and tests wheels,
 # not CPython itself, so these just slow down the build.

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -56,7 +56,6 @@ set -e
 case "${LINUX_VER}" in
   "ubuntu"*)
     rapids-retry apt-get update -y
-    rapids-retry apt-get update -y
     apt-get upgrade -y
 
     PACKAGES_TO_INSTALL=(
@@ -137,8 +136,12 @@ case "${LINUX_VER}" in
         tar -xzvf openssl-1.1.1k.tar.gz
     cd openssl-1.1.1k
     ./config --prefix=/usr --openssldir=/etc/ssl --libdir=lib no-shared zlib-dynamic
-    make
-    make install
+    # 'install_sw' installs just the libraries, headers, and binaries.
+    # Plain 'install' also (slowly) generates and installs the HTML manpages, which we don't need.
+    #
+    # ref: https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/INSTALL
+    #
+    make -j"$(nproc)" install_sw
     popd
     ;;
   *)
@@ -157,6 +160,10 @@ RUN \
 <<EOF
 # install pyenv
 rapids-retry curl https://pyenv.run | bash
+
+# Skip building CPython's own test modules. RAPIDS CI builds and tests wheels,
+# not CPython itself, so these just slow down the build.
+export PYTHON_CONFIGURE_OPTS="--disable-test-modules"
 
 # create environment for the desired Python version
 pyenv install ${PYTHON_VER}

--- a/context/scripts/clean-pyenv
+++ b/context/scripts/clean-pyenv
@@ -12,6 +12,10 @@ find "${PYENV_ROOT}" -type d -name '.github' -exec rm -rf '{}' \+
 # delete docs
 find "${PYENV_ROOT}" -type d -name 'man' -exec rm -rf '{}' \+
 
+# delete __pycache__ files
+find "${PYENV_ROOT}" -type d -name '__pycache__' -exec rm -rf '{}' +
+find "${PYENV_ROOT}" -name '*.pyc' -delete
+
 # delete tests
 find "${PYENV_ROOT}" -type d -name 'test' -exec rm -rf '{}' \+
 

--- a/context/scripts/configure-system-package-managers
+++ b/context/scripts/configure-system-package-managers
@@ -20,6 +20,19 @@ case "${LINUX_VER}" in
       echo 'APT::Acquire::Retries "10";' > /etc/apt/apt.conf.d/retries
       echo 'APT::Acquire::https::Timeout "240";' > /etc/apt/apt.conf.d/https-timeout
       echo 'APT::Acquire::http::Timeout "240";' > /etc/apt/apt.conf.d/http-timeout
+
+      # Don't install documentation files (manpages, docs, etc.). apt/dpkg has no
+      # '--nodocs' flag, so this is configured via dpkg path-exclude rules instead.
+      # Note: this only affects packages installed after this point, not docs
+      # already present in the base image.
+      cat > /etc/dpkg/dpkg.cfg.d/01_nodoc <<'CFG'
+path-exclude /usr/share/doc/*
+path-include /usr/share/doc/*/copyright
+path-exclude /usr/share/man/*
+path-exclude /usr/share/groff/*
+path-exclude /usr/share/info/*
+path-exclude /usr/share/lintian/*
+CFG
       ;;
     "rockylinux"*)
       # Note that `dnf` defaults to 10 retries, so no additional configuration for retries is required here.
@@ -33,6 +46,15 @@ case "${LINUX_VER}" in
           sed -i 's/^best=.*/best=False/' /etc/dnf/dnf.conf; \
       else \
          echo "best=False" >> /etc/dnf/dnf.conf; \
+      fi
+
+      # Don't install documentation files (manpages, docs, etc.) for any 'dnf'
+      # transaction. This makes 'nodocs' the global default, so individual
+      # '--nodocs' / '--setopt=tsflags=nodocs' flags aren't required.
+      if grep -q '^tsflags=' /etc/dnf/dnf.conf; then \
+          sed -i 's/^tsflags=.*/tsflags=nodocs/' /etc/dnf/dnf.conf; \
+      else \
+         echo "tsflags=nodocs" >> /etc/dnf/dnf.conf; \
       fi
       ;;
     *)


### PR DESCRIPTION
Closes #375

Contributes to https://github.com/rapidsai/shared-workflows/issues/505

This PR aims to make `ci-wheel` and `citestwheel` builds faster and images smaller.

* skips building CPython's tests
* skips building OpenSSL's documentation
* skips installing documentation for `apt` and `yum` packages

## Impact

For Rocky Linux 8, Python 3.14, CUDA 13.0.3, x86_64 builds...

**build times**

| image            | latest `main` | this PR              |
|:------------------:|:------------------:|:---------------------:|
| `ci-wheel`      |  17m 29s       |  **13m 23s**  |
| `citestwheel` |  14m 28s      |   **11m 41s**  |

**image size (compressed)**

| image            | latest `main` | this PR               |
|:------------------:|:------------------:|:---------------------:|
| `ci-wheel`      |  4.61GB          | **4.59 GB**    |
| `citestwheel` | 3.56 GB         |  **3.54 GB**   |

And for the entire run of all builds + publishing


|                         | latest `main` | this PR                |
|:------------------:|:------------------:|:----------------------:|
| full CI run      | 36m58s         |   **31m28s**   |

*latest `main`: ([build link](https://github.com/rapidsai/ci-imgs/actions/runs/27961492528/job/82747090293) | [ci-wheel images](https://hub.docker.com/r/rapidsai/ci-wheel/tags?name=26.08-cuda13.0.3-rockylinux8-py3.14-amd64) | [citestwheel images](https://hub.docker.com/r/rapidsai/citestwheel/tags?name=26.08-cuda13.0.3-rockylinux8-py3.14-amd64) )*
*this PR: ([build link]() | [ci-wheel images](https://hub.docker.com/r/rapidsai/staging/tags?name=ci-wheel-425-26.08-cuda13.0.3-rockylinux8-py3.14-amd64) ) | [citestwheel images](https://hub.docker.com/r/rapidsai/staging/tags?name=citestwheel-425-26.08-cuda13.0.3-rockylinux8-py3.14-amd64) )*

The Rocky Linux 8 `ci-wheel` and `citestwheel` images take the longest to build here, because they build CPython, OpenSSL, and `zstd` from source. The gains for `ci-conda` images and for any Ubuntu-based images will be much smaller.