### PR TITLE
feat: add `changed-files` CI filter to `pr.yaml` to skip builds for certain changesets

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -58,4 +58,5 @@ jobs:
           - '!LICENSE'
           - '!README.md'
           - '!SECURITY.md'
+          - '!ci/release/update-version.sh
           - '!renovate.json'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,6 +20,7 @@ jobs:
   pr-builder:
     needs:
       - build-images
+      - changed-files
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
     if: always()
     with:
@@ -30,8 +31,31 @@ jobs:
       pull-requests: read
   build-images:
     uses: ./.github/workflows/build-and-publish-images.yaml
+    needs: changed-files
     with:
       build_type: pull-request
     secrets:
       GPUCIBOT_DOCKERHUB_USER: ${{ secrets.GPUCIBOT_DOCKERHUB_USER }}
       GPUCIBOT_DOCKERHUB_TOKEN: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
+  changed-files:
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      pull-requests: read
+    uses: rapidsai/shared-workflows/.github/workflows/changed-files.yaml@main
+    with:
+      files_yaml: |
+        build_images:
+          - '**'
+          - '!.github/CODEOWNERS'
+          - '!.github/copy-pr-bot.yaml'
+          - '!.github/ops-bot.yaml'
+          - '!.github/zizmor.yml'
+          - '!.gitignore'
+          - '!.pre-commit-config.yaml'
+          - '!CONTRIBUTING.md'
+          - '!LICENSE'
+          - '!README.md'
+          - '!SECURITY.md'
+          - '!renovate.json'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -29,14 +29,6 @@ jobs:
       contents: read
       id-token: write
       pull-requests: read
-  build-images:
-    uses: ./.github/workflows/build-and-publish-images.yaml
-    needs: changed-files
-    with:
-      build_type: pull-request
-    secrets:
-      GPUCIBOT_DOCKERHUB_USER: ${{ secrets.GPUCIBOT_DOCKERHUB_USER }}
-      GPUCIBOT_DOCKERHUB_TOKEN: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
   changed-files:
     permissions:
       actions: read
@@ -60,3 +52,11 @@ jobs:
           - '!SECURITY.md'
           - '!ci/release/update-version.sh
           - '!renovate.json'
+  build-images:
+    uses: ./.github/workflows/build-and-publish-images.yaml
+    needs: changed-files
+    with:
+      build_type: pull-request
+    secrets:
+      GPUCIBOT_DOCKERHUB_USER: ${{ secrets.GPUCIBOT_DOCKERHUB_USER }}
+      GPUCIBOT_DOCKERHUB_TOKEN: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}


### PR DESCRIPTION
As proposed by @jameslamb in #423, we don't need to run the (quite expensive) CI here when we do things like update `renovate.json`
