### PR TITLE
citestwheel: stop shipping LLVM in Ubuntu images

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ If you have the `gh` CLI installed and authenticated, you can use `gh auth token
 
 ```sh
 export LINUX_VER=rockylinux8
-export CUDA_VER=13.1.0
-export PYTHON_VER=3.13
+export CUDA_VER=13.3.0
+export PYTHON_VER=3.14
 export ARCH=amd64
 export GH_TOKEN=$(gh auth token)
 

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -75,7 +75,6 @@ case "${LINUX_VER}" in
       libxml2-dev
       libxmlsec1-dev
       libzstd-dev
-      llvm
       make
       patch
       ssh


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/shared-workflows/issues/505

The Ubuntu `citestwheel` images (but not the Rocky Linux ones) are currently shipping the `llvm` metapackage, which pulls in 240 MB of LLVM packages, including `libLLVM.so` and the `lld` linker.

I don't think we need any of that in those images.

1. we don't ship those in the Rocky Linux 8 images, and wheel testing in those images works without issue
2. they might have originally been included for use with `numba` ([git blame shows `llvm` has been installed in these images as far back as 2022](https://github.com/rapidsai/cibuildwheel-imgs/blob/e955dfb28182e419ebe10fcccece14ce936297a4/citestwheel/Dockerfile#L15)), but that's not necessary with any versions of `numba` we test against... `numba` statically links against LLVM and gets what it needs from `llvmlite`, which itself statically links libLLVM (https://llvmlite.readthedocs.io/en/latest/faqs.html#why-static-linking-to-llvm)

Let's drop this and make these images smaller and therefore faster to download, to help with CI time a bit.

## Notes for Reviewers

### Testing?

Testing new images is kind of a pain ... proposing we just merge this and see if anything breaks.