### PR TITLE
fix(ci): condition image builds on `changed-files` output

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -55,6 +55,7 @@ jobs:
   build-images:
     uses: ./.github/workflows/build-and-publish-images.yaml
     needs: changed-files
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).build_images
     with:
       build_type: pull-request
     secrets:


### PR DESCRIPTION
I forgot to actually use the boolean from `changed-files` to determine whether we run the image builds or not