### PR TITLE
remove 'anaconda-client'

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -227,7 +227,6 @@ fi
 
 # TODO: remove the ceiling on 'rattler-build' (https://github.com/rapidsai/build-planning/issues/259)
 PACKAGES_TO_INSTALL=(
-  'anaconda-client>=1.13.1'
   'ca-certificates>=2026.1.4'
   'certifi>=2026.1.4'
   'conda-build>=25.11.1'

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -277,7 +277,6 @@ pyenv global ${PYTHON_VER}
 rapids-pip-retry install --upgrade 'pip>=25.3'
 
 PACKAGES_TO_INSTALL=(
-  'anaconda-client>=1.13.0'
   'auditwheel>=6.2.0'
   'certifi>=2026.1.4'
   'conda-package-handling>=2.4.0'


### PR DESCRIPTION
https://github.com/rapidsai/shared-workflows/pull/586 switched the `conda-upload-packages` and `wheels-publish` jobs away from using this repo's images... they new use a `python:*-slim` image and install the tools they need at runtime.

As a result, `rapidsai/ci-{conda,wheel}` no longer need to install `anaconda client`, the client library for anaconda.org. This proposes removing it.

It pulls in a lot of dependencies, so this should help a bit with build times and image size (don't have estimates).

## Notes for Reviewers

### Is this safe?

I think so. It appears the only remaining use of this is in `rapidsai/legate-{boost,dataframe}`, which aren't being actively developed:

* `rapidsai`: https://github.com/search?q=org%3Arapidsai+%22anaconda+%22+AND+NOT+is%3Aarchived&type=code
* `NVIDIA`: https://github.com/search?q=org%3ANVIDIA+%22anaconda+%22+AND+NOT+is%3Aarchived&type=code&p=3