### PR TITLE
Use CUDA 13.3 as latest tag

### DIFF
--- a/latest.yaml
+++ b/latest.yaml
@@ -2,15 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Define the values used for the "latest" tag
 ci-conda:
-  CUDA_VER: "13.2.1"
+  CUDA_VER: "13.3.0"
   PYTHON_VER: "3.14"
-  LINUX_VER: "ubuntu24.04"
+  LINUX_VER: "ubuntu26.04"
 ci-wheel:
   CUDA_VER: "13.0.3"
   PYTHON_VER: "3.14"
   # Wheels should always be built with the oldest supported glibc version
   LINUX_VER: "rockylinux8"
 citestwheel:
-  CUDA_VER: "13.2.1"
+  CUDA_VER: "13.3.0"
   PYTHON_VER: "3.14"
-  LINUX_VER: "ubuntu24.04"
+  LINUX_VER: "ubuntu26.04"

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -4,7 +4,6 @@ CUDA_VER:
   - "12.2.2"
   - "12.9.2"
   - "13.0.3"
-  - "13.2.1"
   - "13.3.0"
 PYTHON_VER:
   - "3.11"
@@ -37,14 +36,10 @@ exclude:
     CUDA_VER: "12.9.2"
   - LINUX_VER: "ubuntu26.04"
     CUDA_VER: "13.0.3"
-  - LINUX_VER: "ubuntu26.04"
-    CUDA_VER: "13.2.1"
 
   # Only build ci-wheel for the latest CUDA of each major version,
   # and any others used for builds in CI
   - CUDA_VER: "12.2.2"
-    IMAGE_REPO: "ci-wheel"
-  - CUDA_VER: "13.2.1"
     IMAGE_REPO: "ci-wheel"
 
   # Only build ci-wheel for the oldest glibc (rockylinux8)


### PR DESCRIPTION
Updates `latest` tags to use CUDA 13.3 and Ubuntu 26.04.

Part of https://github.com/rapidsai/build-planning/issues/286.