### PR TITLE
Pin conda to working launcher build

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -39,6 +39,8 @@ EOF
 FROM nvidia/cuda:${CUDA_VER}-base-${LINUX_VER} AS ci-conda
 
 ARG CONDA_ARCH=notset
+ARG CONDA_BUILD_NUMBER=notset
+ARG CONDA_VER=notset
 ARG CUDA_VER=notset
 ARG DEBIAN_FRONTEND=noninteractive
 ARG PYTHON_VER=notset
@@ -99,9 +101,15 @@ chmod g+ws /opt/conda
 # Ensure new files/dirs have group write permissions
 umask 002
 
+# conda 26.5.3 build 1 has launchers with '#!/usr/bin/env python'. When a
+# non-base environment is active, those launchers use that environment's
+# Python and fail to import the conda module from the base environment.
+CONDA_SPEC="conda=${CONDA_VER}=*_${CONDA_BUILD_NUMBER}"
+echo "conda ${CONDA_VER} *_${CONDA_BUILD_NUMBER}" >> /opt/conda/conda-meta/pinned
+
 # force-reinstall 'conda' first, to clear out any files
 # left behind from updates
-rapids-conda-retry install -y -n base --force-reinstall 'conda>=26.5.0'
+rapids-conda-retry install -y -n base --force-reinstall "${CONDA_SPEC}"
 
 
 # install expected Python version
@@ -304,5 +312,15 @@ EOF
 
 # Add pip.conf
 COPY pip.conf /etc/pip.conf
+
+# Verify that conda uses the base environment's Python even when another
+# environment's Python appears first on PATH. This reproduces the failure
+# caused by conda 26.5.3 build 1 without requiring another conda solve.
+RUN <<EOF
+test_env=$(mktemp -d)
+trap 'rm -rf "${test_env}"' EXIT
+/opt/conda/bin/python -m venv "${test_env}"
+PATH="${test_env}/bin:/opt/conda/condabin:${PATH}" conda info
+EOF
 
 CMD ["/bin/bash"]

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -101,9 +101,8 @@ chmod g+ws /opt/conda
 # Ensure new files/dirs have group write permissions
 umask 002
 
-# conda 26.5.3 build 1 has launchers with '#!/usr/bin/env python'. When a
-# non-base environment is active, those launchers use that environment's
-# Python and fail to import the conda module from the base environment.
+# conda 26.5.3 build 1 has non-relocatable launchers. See
+# https://github.com/conda-forge/conda-feedstock/issues/304.
 CONDA_SPEC="conda=${CONDA_VER}=*_${CONDA_BUILD_NUMBER}"
 echo "conda ${CONDA_VER} *_${CONDA_BUILD_NUMBER}" >> /opt/conda/conda-meta/pinned
 
@@ -313,9 +312,8 @@ EOF
 # Add pip.conf
 COPY pip.conf /etc/pip.conf
 
-# Verify that conda uses the base environment's Python even when another
-# environment's Python appears first on PATH. This reproduces the failure
-# caused by conda 26.5.3 build 1 without requiring another conda solve.
+# Verify that conda commands can be run in a child environment. See
+# https://github.com/conda-forge/conda-feedstock/issues/304.
 RUN <<EOF
 test_env=$(mktemp -d)
 trap 'rm -rf "${test_env}"' EXIT

--- a/versions.yaml
+++ b/versions.yaml
@@ -10,8 +10,8 @@ YQ_VER: 4.53.2
 AWS_CLI_VER: 2.28.1
 # renovate: datasource=docker depName=condaforge/miniforge3 versioning=docker
 MINIFORGE_VER: 26.1.0-0
-# conda 26.5.3 build 1 has non-relocatable launchers that use
-# '#!/usr/bin/env python' and fail after another environment is activated.
+# conda 26.5.3 build 1 has non-relocatable launchers. See
+# https://github.com/conda-forge/conda-feedstock/issues/304.
 # Keep this pinned to build 0 until a fixed conda package is available.
 CONDA_VER: 26.5.3
 CONDA_BUILD_NUMBER: 0

--- a/versions.yaml
+++ b/versions.yaml
@@ -10,5 +10,10 @@ YQ_VER: 4.53.2
 AWS_CLI_VER: 2.28.1
 # renovate: datasource=docker depName=condaforge/miniforge3 versioning=docker
 MINIFORGE_VER: 26.1.0-0
+# conda 26.5.3 build 1 has non-relocatable launchers that use
+# '#!/usr/bin/env python' and fail after another environment is activated.
+# Keep this pinned to build 0 until a fixed conda package is available.
+CONDA_VER: 26.5.3
+CONDA_BUILD_NUMBER: 0
 # renovate: datasource=github-releases depName=rapidsai/sccache
 SCCACHE_VER: 0.14.0-rapids.19


### PR DESCRIPTION
## Summary

- pin `conda` to `26.5.3` build `0` in `ci-conda` images
- persist the build constraint in `/opt/conda/conda-meta/pinned` so `conda update --all` cannot select build `1`
- add a build-time regression test that invokes `conda info` with a child environment's Python first on `PATH`

## Root cause

`conda` 26.5.3 build `py314h9e666f3_1`, published after [conda-feedstock#300](https://github.com/conda-forge/conda-feedstock/pull/300), installs launchers with `#!/usr/bin/env python`. Once a non-base environment is active, those launchers select that environment's Python and fail because it does not contain the base environment's `conda` module.

This caused [RMM job 84470937540](https://github.com/rapidsai/rmm/actions/runs/28498318613/job/84470937540) to fail with `ModuleNotFoundError: No module named 'conda'`. The preceding [passing job](https://github.com/rapidsai/rmm/actions/runs/28469582829/job/84379600648) used build `py314hdafbbf9_0`, whose launchers point to `/opt/conda/bin/python`.

## Validation

- ran `conda update --all` in the known-good image with `conda 26.5.3 *_0` in the pinned-spec file; Conda remained on `py314hdafbbf9_0`
- created a Python venv, placed its `bin` directory first on `PATH`, and confirmed `conda info` succeeds
- confirmed `ci/compute-build-args.sh` emits `CONDA_VER=26.5.3` and `CONDA_BUILD_NUMBER=0`
- ran `pre-commit run --all-files`; all hooks passed
