### PR TITLE
Unpin conda launcher build

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -39,8 +39,6 @@ EOF
 FROM nvidia/cuda:${CUDA_VER}-base-${LINUX_VER} AS ci-conda
 
 ARG CONDA_ARCH=notset
-ARG CONDA_BUILD_NUMBER=notset
-ARG CONDA_VER=notset
 ARG CUDA_VER=notset
 ARG DEBIAN_FRONTEND=noninteractive
 ARG PYTHON_VER=notset
@@ -101,14 +99,9 @@ chmod g+ws /opt/conda
 # Ensure new files/dirs have group write permissions
 umask 002
 
-# conda 26.5.3 build 1 has non-relocatable launchers. See
-# https://github.com/conda-forge/conda-feedstock/issues/304.
-CONDA_SPEC="conda=${CONDA_VER}=*_${CONDA_BUILD_NUMBER}"
-echo "conda ${CONDA_VER} *_${CONDA_BUILD_NUMBER}" >> /opt/conda/conda-meta/pinned
-
 # force-reinstall 'conda' first, to clear out any files
 # left behind from updates
-rapids-conda-retry install -y -n base --force-reinstall "${CONDA_SPEC}"
+rapids-conda-retry install -y -n base --force-reinstall 'conda>=26.5.0'
 
 
 # install expected Python version

--- a/versions.yaml
+++ b/versions.yaml
@@ -10,10 +10,5 @@ YQ_VER: 4.53.2
 AWS_CLI_VER: 2.28.1
 # renovate: datasource=docker depName=condaforge/miniforge3 versioning=docker
 MINIFORGE_VER: 26.1.0-0
-# conda 26.5.3 build 1 has non-relocatable launchers. See
-# https://github.com/conda-forge/conda-feedstock/issues/304.
-# Keep this pinned to build 0 until a fixed conda package is available.
-CONDA_VER: 26.5.3
-CONDA_BUILD_NUMBER: 0
 # renovate: datasource=github-releases depName=rapidsai/sccache
 SCCACHE_VER: 0.14.0-rapids.19


### PR DESCRIPTION
## Summary

- remove the temporary conda version and build pin added in #437
- restore the existing `conda>=26.5.0` installation constraint
- retain the child-environment regression test for the launcher issue

## Dependency

This draft depends on the fixed conda builds from conda-forge/conda-feedstock#306 being published and available through conda-forge repodata.