### PR TITLE
ci-wheel: drop CUDA 13.0 images

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -41,6 +41,8 @@ exclude:
   # and any others used for builds in CI
   - CUDA_VER: "12.2.2"
     IMAGE_REPO: "ci-wheel"
+  - CUDA_VER: "13.0.3"
+    IMAGE_REPO: "ci-wheel"
 
   # Only build ci-wheel for the oldest glibc (rockylinux8)
   - LINUX_VER: "ubuntu22.04"


### PR DESCRIPTION
Drops `ci-wheel` CUDA 13.0 builds.

This is safe to do once all of RAPIDS is building wheels on a later CTK (https://github.com/rapidsai/build-planning/issues/268).