### PR TITLE
Update ci-wheel latest to CUDA 13.3.0

### DIFF
--- a/latest.yaml
+++ b/latest.yaml
@@ -6,7 +6,7 @@ ci-conda:
   PYTHON_VER: "3.14"
   LINUX_VER: "ubuntu26.04"
 ci-wheel:
-  CUDA_VER: "13.0.3"
+  CUDA_VER: "13.3.0"
   PYTHON_VER: "3.14"
   # Wheels should always be built with the oldest supported glibc version
   LINUX_VER: "rockylinux8"


### PR DESCRIPTION
This PR updates the ci-wheel latest CUDA version to 13.3.0, since #440 removed 13.0.3 from the current build matrix.