### PR TITLE
Add gdb to citestwheel images

### DIFF
--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -62,6 +62,7 @@ case "${LINUX_VER}" in
       build-essential
       ca-certificates
       curl
+      gdb
       git
       jq
       libbz2-dev
@@ -111,6 +112,7 @@ case "${LINUX_VER}" in
       curl
       dnf-plugins-core
       gcc
+      gdb
       git
       jq
       libffi-devel


### PR DESCRIPTION
For some test runs in rapidsmpf and cudf-polars, we use gdb to attach to, and capture stack traces of, hanging tests. This helps diagnosing CI errors that are hard to reproduce locally. This requires gdb in the citestwheel image because, unlike conda images, we have no way of installing it locally.