### PR TITLE
Backport PR 442 to fix ci-wheel latest tags

### DIFF
--- a/latest.yaml
+++ b/latest.yaml
@@ -6,7 +6,7 @@ ci-conda:
   PYTHON_VER: "3.14"
   LINUX_VER: "ubuntu26.04"
 ci-wheel:
-  CUDA_VER: "13.0.3"
+  CUDA_VER: "13.3.0"
   PYTHON_VER: "3.14"
   # Wheels should always be built with the oldest supported glibc version
   LINUX_VER: "rockylinux8"


### PR DESCRIPTION
We need to publish new ci-imgs on `release/26.08` to get https://github.com/rapidsai/gha-tools/pull/267. However, there is a bug in the matrix (literally):

```
latest.yaml entry for 'ci-wheel' (CUDA_VER=13.0.3, PYTHON_VER=3.14, LINUX_VER=rockylinux8) does not match any entry in the build matrix.
```

This PR backports #442.