### PR TITLE
Require DFG >=1.22

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -236,7 +236,7 @@ PACKAGES_TO_INSTALL=(
   'jq>=1.8.1'
   'packaging>=25.0'
   "python>=${PYTHON_VERSION},<${PYTHON_UPPER_BOUND}=*_${PYTHON_ABI_TAG}"
-  'rapids-dependency-file-generator==1.*'
+  'rapids-dependency-file-generator==1.*,>=1.22'
   'rattler-build>=0.55.0,<0.58'
 )
 

--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -283,7 +283,7 @@ PACKAGES_TO_INSTALL=(
   'dunamai>=1.25.0'
   'patchelf>=0.17.2.4'
   'pydistcheck==0.11.*'
-  'rapids-dependency-file-generator==1.*'
+  'rapids-dependency-file-generator==1.*,>=1.22'
   'twine>=6.2.0'
   'wheel>=0.45.1'
 )

--- a/citestwheel.Dockerfile
+++ b/citestwheel.Dockerfile
@@ -199,7 +199,7 @@ python --version
 rapids-pip-retry install --upgrade pip
 rapids-pip-retry install \
   'certifi>=2026.1.4' \
-  'rapids-dependency-file-generator==1.*'
+  'rapids-dependency-file-generator==1.*,>=1.22'
 
 pyenv rehash
 


### PR DESCRIPTION
In order for projects to use the new `constraints` output type in v1.22.0, we have to ensure that rapids-dependency-file-generator is always v1.22.0 or greater.

Contributes to https://github.com/rapidsai/build-planning/issues/311