### PR TITLE
ci-wheel: add 'abi3audit'

### DIFF
--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -277,6 +277,7 @@ pyenv global ${PYTHON_VER}
 rapids-pip-retry install --upgrade 'pip>=25.3'
 
 PACKAGES_TO_INSTALL=(
+  'abi3audit>=0.0.26'
   'auditwheel>=6.2.0'
   'certifi>=2026.1.4'
   'conda-package-handling>=2.4.0'


### PR DESCRIPTION
In https://github.com/rapidsai/build-planning/issues/315, I'm proposing using `abi3audit` everywhere in RAPIDS to help discover issues in our ABI 3 wheels.

That'll be used so broadly that I think it's worth pre-installing in the `ci-wheel` images.