### PR TITLE
ci-conda: remove 'envsubst' and 'gettext', put floor on conda

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -21,8 +21,13 @@ umask 002
 /tmp/build-scripts/install-tools \
   --gha-tools
 
-# Example of pinned package in case you require an override
-# echo '<PACKAGE_NAME>==<VERSION>' >> /opt/conda/conda-meta/pinned
+# set up pins that apply to all later solves
+mkdir -p /opt/conda/conda-meta
+cat > /opt/conda/conda-meta/pinned <<EOF_PINNED
+# avoid solves that downgrade conda, because they can put the environment
+# into a hard-to-fix state
+conda >=26.7
+EOF_PINNED
 
 # update everything before other environment changes, to ensure mixing
 # an older conda with newer packages still works well

--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -206,12 +206,12 @@ COPY condarc.tmpl /tmp/condarc.tmpl
 
 # Install CI tools using conda
 RUN <<EOF
-# Install prereq for envsubst
-rapids-conda-retry install -y \
-  gettext
-
-# create condarc file from env vars
-cat /tmp/condarc.tmpl | envsubst | tee /opt/conda/.condarc; \
+# update condarc file from env vars
+sed \
+  -e "s|\$RAPIDS_CONDA_BLD_ROOT_DIR|${RAPIDS_CONDA_BLD_ROOT_DIR}|g" \
+  -e "s|\$RAPIDS_CONDA_BLD_OUTPUT_DIR|${RAPIDS_CONDA_BLD_OUTPUT_DIR}|g" \
+  /tmp/condarc.tmpl \
+  > /opt/conda/.condarc
 rm -f /tmp/condarc.tmpl
 
 PYTHON_MAJOR_VERSION=${PYTHON_VERSION%%.*}


### PR DESCRIPTION
Fixes https://github.com/rapidsai/ci-imgs/issues/455

`ci-conda` builds started failing recently (only on arm64 + Python 3.11/3.12), hitting timeouts during `conda install` of some tools. This proposes 2 changes:

* replacing `envsubst` (and therefore a `conda install gettext`) with `sed` for templating environment variables into `.condarc`
* putting a floor on `conda` itself in `conda-meta/pinned`, to prevent downgrades

## Notes for Reviewers

As a side effect, this removes `gettext` from the `ci-conda` images.

At a glance, it doesn't look to be needed anywhere:

* `envsubst` search: https://github.com/search?q=%22envsubst%22+%28org%3Arapidsai+OR+org%3ANVIDIA%29+AND+NOT+is%3Aarchived&type=code
* `gettext` search: https://github.com/search?q=%22gettext%22+%28org%3Arapidsai+OR+org%3ANVIDIA%29+AND+NOT+is%3Aarchived+language%3AShell&type=code&p=1&l=Shell

Proposing we just merge this, and if it turns out that something had a dependency on it, make a decision then about whether to add `envsubst` / `gettext` back here or do a more localized fix.