### PR TITLE
remove comments from conda-meta/pinned

### DIFF
--- a/ci-conda.Dockerfile
+++ b/ci-conda.Dockerfile
@@ -22,10 +22,11 @@ umask 002
   --gha-tools
 
 # set up pins that apply to all later solves
+#
+# * 'conda': avoid solves that downgrade conda, because they can put the environment into a hard-to-fix state
+#
 mkdir -p /opt/conda/conda-meta
 cat > /opt/conda/conda-meta/pinned <<EOF_PINNED
-# avoid solves that downgrade conda, because they can put the environment
-# into a hard-to-fix state
 conda >=26.7
 EOF_PINNED
 


### PR DESCRIPTION
Follow-up to #456 

It looks like `mamba` does not handle comments in `conda-meta/pinned`.

> critical libmamba Error parsing version "avoid solves that downgrade conda". Version contains invalid characters in avoid solves that downgrade conda.

`integration` build: https://github.com/rapidsai/integration/actions/runs/31784097846/job/94716855110

This removes them.