### PR TITLE
Install build in ci-wheel image

### DIFF
--- a/ci-wheel.Dockerfile
+++ b/ci-wheel.Dockerfile
@@ -279,6 +279,7 @@ rapids-pip-retry install --upgrade 'pip>=25.3'
 PACKAGES_TO_INSTALL=(
   'abi3audit>=0.0.26'
   'auditwheel>=6.2.0'
+  'build>=1.5.1'
   'certifi>=2026.1.4'
   'conda-package-handling>=2.4.0'
   'dunamai>=1.25.0'


### PR DESCRIPTION
## Description

Install `pypa/build>=1.5.1` in the `ci-wheel` image. RAPIDS wheel builders use `python -m build --wheel`, including `--env-dir`, which was introduced in build 1.5.1.

## Checklist

- [x] I have read the contributing guidelines.
- [x] This commit is DCO signed.
- [x] The change has been validated.